### PR TITLE
Refine and test StreamingResponseHandler

### DIFF
--- a/trino-s3-proxy/src/main/java/io/trino/s3/proxy/server/rest/StreamingResponseHandler.java
+++ b/trino-s3-proxy/src/main/java/io/trino/s3/proxy/server/rest/StreamingResponseHandler.java
@@ -18,14 +18,10 @@ import io.airlift.http.client.HeaderName;
 import io.airlift.http.client.Request;
 import io.airlift.http.client.Response;
 import io.airlift.http.client.ResponseHandler;
-import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.container.AsyncResponse;
 import jakarta.ws.rs.core.StreamingOutput;
 
 import java.io.InputStream;
-import java.time.Duration;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import static io.airlift.http.client.ResponseHandlerUtils.propagate;
 import static java.util.Objects.requireNonNull;
@@ -34,12 +30,10 @@ class StreamingResponseHandler
         implements ResponseHandler<Void, RuntimeException>
 {
     private final AsyncResponse asyncResponse;
-    private final Duration maxWaitForResponse;
 
-    StreamingResponseHandler(AsyncResponse asyncResponse, Duration maxWaitForResponse)
+    StreamingResponseHandler(AsyncResponse asyncResponse)
     {
         this.asyncResponse = requireNonNull(asyncResponse, "asyncResponse is null");
-        this.maxWaitForResponse = requireNonNull(maxWaitForResponse, "maxWaitForResponse is null");
     }
 
     @Override
@@ -53,15 +47,14 @@ class StreamingResponseHandler
     public Void handle(Request request, Response response)
             throws RuntimeException
     {
-        CountDownLatch latch = new CountDownLatch(1);
         StreamingOutput streamingOutput = output -> {
-            try {
-                InputStream inputStream = response.getInputStream();
-                ByteStreams.copy(inputStream, output);
-            }
-            finally {
-                latch.countDown();
-            }
+            InputStream inputStream = response.getInputStream();
+
+            // HttpClient/Jersey timeouts control behavior. The configured HttpClient idle timeout
+            // controls whether the InputStream will time out. Jersey configuration controls
+            // OutputStream and general request timeouts.
+            ByteStreams.copy(inputStream, output);
+            output.flush();
         };
 
         jakarta.ws.rs.core.Response.ResponseBuilder responseBuilder = jakarta.ws.rs.core.Response.status(response.getStatusCode()).entity(streamingOutput);
@@ -71,21 +64,8 @@ class StreamingResponseHandler
                 .map(HeaderName::toString)
                 .forEach(name -> response.getHeaders(name).forEach(value -> responseBuilder.header(name, value)));
 
-        try {
-            asyncResponse.resume(responseBuilder.build());
-        }
-        catch (Exception e) {
-            throw new WebApplicationException(e, jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR);
-        }
-        try {
-            if (!latch.await(maxWaitForResponse.toMillis(), TimeUnit.MILLISECONDS)) {
-                throw new WebApplicationException(jakarta.ws.rs.core.Response.Status.REQUEST_TIMEOUT);
-            }
-        }
-        catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new WebApplicationException(jakarta.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE);
-        }
+        // this will block until StreamingOutput completes
+        asyncResponse.resume(responseBuilder.build());
 
         return null;
     }

--- a/trino-s3-proxy/src/main/java/io/trino/s3/proxy/server/rest/TrinoS3ProxyClient.java
+++ b/trino-s3-proxy/src/main/java/io/trino/s3/proxy/server/rest/TrinoS3ProxyClient.java
@@ -115,8 +115,7 @@ public class TrinoS3ProxyClient
 
         Request realRequest = realRequestBuilder.build();
 
-        // TODO config a max time to wait
-        executorService.submit(() -> httpClient.execute(realRequest, new StreamingResponseHandler(asyncResponse, Duration.ofHours(1))));
+        executorService.submit(() -> httpClient.execute(realRequest, new StreamingResponseHandler(asyncResponse)));
     }
 
     private static String rewriteRequestPath(ContainerRequest request, String bucket)

--- a/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/rest/HangingResource.java
+++ b/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/rest/HangingResource.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.s3.proxy.server.rest;
+
+import com.google.inject.Inject;
+import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.Request;
+import io.trino.s3.proxy.server.rest.TestHangingStreamingResponseHandler.ForTimeout;
+import jakarta.annotation.PreDestroy;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.container.AsyncResponse;
+import jakarta.ws.rs.container.Suspended;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.StreamingOutput;
+import jakarta.ws.rs.core.UriInfo;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static com.google.common.util.concurrent.MoreExecutors.shutdownAndAwaitTermination;
+import static io.airlift.http.client.Request.Builder.prepareGet;
+import static jakarta.ws.rs.core.HttpHeaders.CONTENT_LENGTH;
+import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+import static java.util.Objects.requireNonNull;
+
+@Path("/")
+public class HangingResource
+{
+    private final HttpClient httpClient;
+    private final ExecutorService executorService = Executors.newVirtualThreadPerTaskExecutor();
+
+    @Inject
+    public HangingResource(@ForTimeout HttpClient httpClient)
+    {
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
+    }
+
+    @PreDestroy
+    public void shutDown()
+    {
+        shutdownAndAwaitTermination(executorService, Duration.ofSeconds(30));
+    }
+
+    @GET
+    public void callHangingRequest(@Context UriInfo uriInfo, @Suspended AsyncResponse asyncResponse)
+    {
+        // simulate calling a remote request and streaming the result while the remote server hangs
+        Request request = prepareGet().setUri(uriInfo.getBaseUri().resolve("hang")).build();
+        httpClient.execute(request, new StreamingResponseHandler(asyncResponse));
+    }
+
+    @GET
+    @Path("/hang")
+    public void hang(@Suspended AsyncResponse asyncResponse)
+    {
+        StreamingOutput streamingOutput = output -> {
+            // simulate the start of a JSON string
+            output.write('"');
+
+            // write enough bytes so that the StreamingResponseHandler gets called
+            byte[] bytes = new byte[16384];
+            Arrays.fill(bytes, (byte) ' ');
+            output.write(bytes);
+            output.flush();
+
+            // simulate a hanging remote request by never returning
+            try {
+                Thread.currentThread().join();
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        };
+
+        Response response = Response.ok(streamingOutput)
+                .header(CONTENT_TYPE, APPLICATION_JSON_TYPE)
+                .header(CONTENT_LENGTH, "99999999")
+                .build();
+        asyncResponse.resume(response);
+    }
+}

--- a/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/rest/TestHangingStreamingResponseHandler.java
+++ b/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/rest/TestHangingStreamingResponseHandler.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.s3.proxy.server.rest;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.BindingAnnotation;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.bootstrap.LifeCycleManager;
+import io.airlift.event.client.EventModule;
+import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.Request;
+import io.airlift.http.server.testing.TestingHttpServer;
+import io.airlift.http.server.testing.TestingHttpServerModule;
+import io.airlift.jaxrs.JaxrsModule;
+import io.airlift.json.JsonModule;
+import io.airlift.node.testing.TestingNodeModule;
+import io.airlift.units.Duration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.io.EOFException;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static io.airlift.http.client.HttpClientBinder.httpClientBinder;
+import static io.airlift.http.client.JsonResponseHandler.createJsonResponseHandler;
+import static io.airlift.http.client.Request.Builder.prepareGet;
+import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
+import static io.airlift.json.JsonCodec.jsonCodec;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@TestInstance(PER_CLASS)
+public class TestHangingStreamingResponseHandler
+{
+    private static final Duration TIMEOUT = new Duration(1, TimeUnit.SECONDS);
+    private static final Duration NO_TIMEOUT = new Duration(1, TimeUnit.DAYS);
+
+    private final Injector injector;
+
+    @Retention(RUNTIME)
+    @Target({FIELD, PARAMETER, METHOD})
+    @BindingAnnotation
+    public @interface ForTimeout {}
+
+    @Retention(RUNTIME)
+    @Target({FIELD, PARAMETER, METHOD})
+    @BindingAnnotation
+    public @interface ForNoTimeout {}
+
+    public TestHangingStreamingResponseHandler()
+    {
+        Module module = binder -> {
+            jaxrsBinder(binder).bind(HangingResource.class);
+
+            httpClientBinder(binder).bindHttpClient("test", ForTimeout.class)
+                    .withConfigDefaults(config -> config.setRequestTimeout(TIMEOUT)
+                            .setIdleTimeout(TIMEOUT));
+
+            httpClientBinder(binder).bindHttpClient("test", ForNoTimeout.class)
+                    .withConfigDefaults(config -> config.setRequestTimeout(NO_TIMEOUT)
+                            .setIdleTimeout(NO_TIMEOUT));
+        };
+
+        List<Module> modules = ImmutableList.of(
+                module,
+                new TestingNodeModule(),
+                new EventModule(),
+                new JaxrsModule(),
+                new JsonModule(),
+                new TestingHttpServerModule());
+
+        Bootstrap app = new Bootstrap(modules);
+        injector = app.initialize();
+    }
+
+    @AfterAll
+    public void shutDown()
+    {
+        injector.getInstance(LifeCycleManager.class).stop();
+    }
+
+    @Test
+    public void testStreamingResponseWithHang()
+    {
+        URI baseUrl = injector.getInstance(TestingHttpServer.class).getBaseUrl();
+        HttpClient httpClient = injector.getInstance(Key.get(HttpClient.class, ForNoTimeout.class));
+
+        Request request = prepareGet().setUri(baseUrl).build();
+        assertThatThrownBy(() -> httpClient.execute(request, createJsonResponseHandler(jsonCodec(String.class))))
+                .hasRootCauseInstanceOf(EOFException.class);
+    }
+}


### PR DESCRIPTION
The latch that was used wasn't doing anything. Remove it with the understanding the configured timeouts for the HttpClient and Jersey/Glassfish will handle any timeout issues.

Added a test to prove that timeouts are applied.

FYI - I tested this locally with a 32MB S3 file and it seems to work well.