### PR TITLE
A few bug fixes

### DIFF
--- a/trino-s3-proxy/src/main/java/io/trino/s3/proxy/server/credentials/Signer.java
+++ b/trino-s3-proxy/src/main/java/io/trino/s3/proxy/server/credentials/Signer.java
@@ -114,6 +114,7 @@ final class Signer
         Aws4SignerParams.Builder<?> signerParamsBuilder = Aws4SignerParams.builder()
                 .signingName(serviceName)
                 .signingRegion(Region.of(region))
+                .doubleUrlEncode(false)
                 .awsCredentials(AwsBasicCredentials.create(accessKey, secretKey));
 
         String xAmzDate = Optional.ofNullable(requestHeaders.getFirst("x-amz-date")).orElseThrow(() -> {

--- a/trino-s3-proxy/src/main/java/io/trino/s3/proxy/server/credentials/Signer.java
+++ b/trino-s3-proxy/src/main/java/io/trino/s3/proxy/server/credentials/Signer.java
@@ -13,7 +13,6 @@
  */
 package io.trino.s3.proxy.server.credentials;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HostAndPort;
 import io.airlift.log.Logger;
@@ -46,8 +45,9 @@ final class Signer
 {
     private static final Logger log = Logger.get(Signer.class);
 
-    @VisibleForTesting
-    static final DateTimeFormatter AMZ_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'", Locale.US).withZone(ZoneId.of("Z"));
+    static final ZoneId ZONE = ZoneId.of("Z");
+    static final ZoneId UTC = ZoneId.of("UTC");
+    static final DateTimeFormatter AMZ_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'", Locale.US).withZone(ZONE);
 
     private static final Set<String> IGNORED_HEADERS = ImmutableSet.of(
             "x-amzn-trace-id",

--- a/trino-s3-proxy/src/main/java/io/trino/s3/proxy/server/credentials/SigningController.java
+++ b/trino-s3-proxy/src/main/java/io/trino/s3/proxy/server/credentials/SigningController.java
@@ -19,10 +19,13 @@ import jakarta.ws.rs.core.MultivaluedMap;
 
 import java.net.URI;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
+import static io.trino.s3.proxy.server.credentials.Signer.AMZ_DATE_FORMAT;
+import static io.trino.s3.proxy.server.credentials.Signer.UTC;
 import static java.util.Objects.requireNonNull;
 
 public class SigningController
@@ -35,6 +38,11 @@ public class SigningController
     {
         this.credentialsController = requireNonNull(credentialsController, "credentialsController is null");
         maxClockDrift = signingControllerConfig.getMaxClockDrift().toJavaTime();
+    }
+
+    public static String formatRequestInstant(Instant instant)
+    {
+        return instant.atZone(UTC).format(AMZ_DATE_FORMAT);
     }
 
     public Optional<SigningMetadata> signingMetadataFromRequest(


### PR DESCRIPTION
Some ad hoc testing revealed a few bugs.

- Use `now()` when making the real request
- Signer must not double encode URLs