### PR TITLE
AWS signatures, buckets, etc. need a real hostname

### DIFF
--- a/trino-s3-proxy/src/main/java/io/trino/s3/proxy/server/rest/S3EndpointBuilder.java
+++ b/trino-s3-proxy/src/main/java/io/trino/s3/proxy/server/rest/S3EndpointBuilder.java
@@ -20,14 +20,17 @@ import java.net.URI;
 @FunctionalInterface
 public interface S3EndpointBuilder
 {
-    S3EndpointBuilder STANDARD = (uriBuilder, path, bucket, region) -> {
-        String host = bucket.isEmpty() ? "s3.%s.amazonaws.com".formatted(region) : "%s.s3.%s.amazonaws.com".formatted(bucket, region);
+    S3EndpointBuilder STANDARD = (uriBuilder, path, bucket, region) -> buildEndpoint(uriBuilder, "amazonaws.com", -1, true, path, bucket, region);
+
+    static URI buildEndpoint(UriBuilder uriBuilder, String domain, int port, boolean https, String path, String bucket, String region)
+    {
+        String host = bucket.isEmpty() ? "s3.%s.%s".formatted(region, domain) : "%s.s3.%s.%s".formatted(bucket, region, domain);
         return uriBuilder.host(host)
-                .port(-1)
-                .scheme("https")
+                .port(port)
+                .scheme(https ? "https" : "http")
                 .replacePath(path)
                 .build();
-    };
+    }
 
     URI buildEndpoint(UriBuilder uriBuilder, String path, String bucket, String region);
 }

--- a/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/testing/TestingTrinoS3ProxyServer.java
+++ b/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/testing/TestingTrinoS3ProxyServer.java
@@ -32,6 +32,9 @@ import java.util.Collection;
 public final class TestingTrinoS3ProxyServer
         implements Closeable
 {
+    // a wildcard DNS we've registered that resolves to 127.0.0.1
+    public static final String LOCAL_HOSTNAME = "local.gate0.net";
+
     private final Injector injector;
 
     private TestingTrinoS3ProxyServer(Injector injector)


### PR DESCRIPTION
For testing, use `local.gate0.net` instead of `localhost` and/or
IP hostnames for more accurate testing. Host names are used in
signature generation, bucket specification, etc.