### PR TITLE
Separate the TestingControllers and our specific implementations of them

### DIFF
--- a/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/LocalServer.java
+++ b/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/LocalServer.java
@@ -38,9 +38,8 @@ public final class LocalServer
         String realSecretKey = args[3];
         Credentials credentials = new Credentials(new Credentials.Credential(emulatedAccessKey, emulatedSecretKey), new Credentials.Credential(realAccessKey, realSecretKey));
 
-        TestingTrinoS3ProxyServer trinoS3ProxyServer = TestingTrinoS3ProxyServer.builder()
-                .addCredentials(credentials)
-                .buildAndStart();
+        TestingTrinoS3ProxyServer trinoS3ProxyServer = TestingTrinoS3ProxyServer.builder().buildAndStart();
+        trinoS3ProxyServer.getCredentialsController().addCredentials(credentials);
 
         log.info("======== TESTING SERVER STARTED ========");
 

--- a/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/testing/ContainerS3Facade.java
+++ b/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/testing/ContainerS3Facade.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.s3.proxy.server.testing;
+
+import com.google.inject.Inject;
+import io.trino.s3.proxy.server.remote.PathStyleRemoteS3Facade;
+
+import java.util.Optional;
+
+public class ContainerS3Facade
+        extends PathStyleRemoteS3Facade
+{
+    private final ManagedS3MockContainer.ContainerHost containerHost;
+
+    @Inject
+    public ContainerS3Facade(ManagedS3MockContainer s3MockContainer, TestingRemoteS3Facade delegatingFacade)
+    {
+        this(s3MockContainer.getContainerHost(), delegatingFacade);
+    }
+
+    private ContainerS3Facade(ManagedS3MockContainer.ContainerHost containerHost, TestingRemoteS3Facade delegatingFacade)
+    {
+        super(containerHost.host(), false, Optional.of(containerHost.port()));
+        this.containerHost = containerHost;
+        delegatingFacade.setDelegate(this);
+    }
+
+    @Override
+    protected String buildHost(String ignore)
+    {
+        return containerHost.host();
+    }
+}

--- a/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/testing/TestingConstants.java
+++ b/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/testing/TestingConstants.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.s3.proxy.server.testing;
+
+import com.google.inject.BindingAnnotation;
+import io.trino.s3.proxy.server.credentials.Credentials;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.UUID;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+public final class TestingConstants
+{
+    public static final Credentials TESTING_CREDENTIALS = new Credentials(
+            new Credentials.Credential(UUID.randomUUID().toString(), UUID.randomUUID().toString()),
+            new Credentials.Credential(UUID.randomUUID().toString(), UUID.randomUUID().toString()));
+
+    @Retention(RUNTIME)
+    @Target({FIELD, PARAMETER, METHOD})
+    @BindingAnnotation
+    public @interface ForTestingCredentials {}
+
+    private TestingConstants() {}
+}

--- a/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/testing/TestingRemoteS3Facade.java
+++ b/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/testing/TestingRemoteS3Facade.java
@@ -13,28 +13,27 @@
  */
 package io.trino.s3.proxy.server.testing;
 
-import com.google.inject.Inject;
-import io.trino.s3.proxy.server.remote.PathStyleRemoteS3Facade;
+import io.trino.s3.proxy.server.remote.RemoteS3Facade;
+import jakarta.ws.rs.core.UriBuilder;
 
-import java.util.Optional;
+import java.net.URI;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.Objects.requireNonNull;
 
 public class TestingRemoteS3Facade
-        extends PathStyleRemoteS3Facade
+        implements RemoteS3Facade
 {
-    private final String host;
-
-    @SuppressWarnings("resource")
-    @Inject
-    public TestingRemoteS3Facade(ManagedS3MockContainer s3MockContainer)
-    {
-        super(s3MockContainer.container().getHost(), false, Optional.of(s3MockContainer.container().getFirstMappedPort()));
-
-        host = s3MockContainer.container().getHost();
-    }
+    private final AtomicReference<RemoteS3Facade> delegate = new AtomicReference<>();
 
     @Override
-    protected String buildHost(String ignore)
+    public URI buildEndpoint(UriBuilder uriBuilder, String path, String bucket, String region)
     {
-        return host;
+        return requireNonNull(delegate.get(), "delegate is null").buildEndpoint(uriBuilder, path, bucket, region);
+    }
+
+    public void setDelegate(RemoteS3Facade delegate)
+    {
+        this.delegate.set(requireNonNull(delegate, "delegate is null"));
     }
 }

--- a/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/testing/TestingTrinoS3ProxyServer.java
+++ b/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/testing/TestingTrinoS3ProxyServer.java
@@ -24,7 +24,6 @@ import io.airlift.http.server.testing.TestingHttpServerModule;
 import io.airlift.jaxrs.JaxrsModule;
 import io.airlift.json.JsonModule;
 import io.airlift.node.testing.TestingNodeModule;
-import io.trino.s3.proxy.server.credentials.Credentials;
 
 import java.io.Closeable;
 import java.util.Collection;
@@ -50,6 +49,11 @@ public final class TestingTrinoS3ProxyServer
         return injector;
     }
 
+    public TestingCredentialsController getCredentialsController()
+    {
+        return injector.getInstance(TestingCredentialsController.class);
+    }
+
     public static Builder builder()
     {
         return new Builder();
@@ -57,15 +61,10 @@ public final class TestingTrinoS3ProxyServer
 
     public static class Builder
     {
-        private final ImmutableSet.Builder<Credentials> credentials = ImmutableSet.builder();
         private final ImmutableSet.Builder<Module> modules = ImmutableSet.builder();
 
-        private Builder() {}
-
-        public Builder addCredentials(Credentials credentials)
+        private Builder()
         {
-            this.credentials.add(credentials);
-            return this;
         }
 
         public Builder addModule(Module module)
@@ -76,12 +75,7 @@ public final class TestingTrinoS3ProxyServer
 
         public TestingTrinoS3ProxyServer buildAndStart()
         {
-            TestingTrinoS3ProxyServer trinoS3ProxyServer = start(modules.build());
-
-            TestingCredentialsController credentialsController = trinoS3ProxyServer.injector.getInstance(TestingCredentialsController.class);
-            credentials.build().forEach(credentialsController::addCredentials);
-
-            return trinoS3ProxyServer;
+            return start(modules.build());
         }
     }
 

--- a/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/testing/harness/TrinoS3ProxyTestExtension.java
+++ b/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/testing/harness/TrinoS3ProxyTestExtension.java
@@ -16,9 +16,11 @@ package io.trino.s3.proxy.server.testing.harness;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
-import io.trino.s3.proxy.server.credentials.Credentials.Credential;
+import io.trino.s3.proxy.server.credentials.Credentials;
+import io.trino.s3.proxy.server.testing.ContainerS3Facade;
 import io.trino.s3.proxy.server.testing.ManagedS3MockContainer;
 import io.trino.s3.proxy.server.testing.ManagedS3MockContainer.ForS3MockContainer;
+import io.trino.s3.proxy.server.testing.TestingConstants.ForTestingCredentials;
 import io.trino.s3.proxy.server.testing.TestingS3ClientProvider;
 import io.trino.s3.proxy.server.testing.TestingTrinoS3ProxyServer;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -30,11 +32,11 @@ import software.amazon.awssdk.services.s3.S3Client;
 
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.s3.proxy.server.testing.TestingConstants.TESTING_CREDENTIALS;
 
 public class TrinoS3ProxyTestExtension
         implements TestInstanceFactory, TestInstancePreDestroyCallback
@@ -60,15 +62,15 @@ public class TrinoS3ProxyTestExtension
             builder = filter.filter(builder);
         }
 
-        Credential containerCredential = new Credential(UUID.randomUUID().toString(), UUID.randomUUID().toString());
-
         TestingTrinoS3ProxyServer trinoS3ProxyServer = builder
                 .addModule(binder -> {
                     binder.bind(String.class).annotatedWith(ForS3MockContainer.class).toInstance(trinoS3ProxyTest.initialBuckets());
-                    binder.bind(Credential.class).annotatedWith(ForS3MockContainer.class).toInstance(containerCredential);
+                    binder.bind(Credentials.class).annotatedWith(ForTestingCredentials.class).toInstance(TESTING_CREDENTIALS);
                     binder.bind(ManagedS3MockContainer.class).asEagerSingleton();
+                    binder.bind(ContainerS3Facade.class).asEagerSingleton();
                 })
                 .buildAndStart();
+        trinoS3ProxyServer.getCredentialsController().addCredentials(TESTING_CREDENTIALS);
         testingServersRegistry.put(extensionContext.getUniqueId(), trinoS3ProxyServer);
 
         Injector injector = trinoS3ProxyServer.getInjector()


### PR DESCRIPTION
This PR aims to:

**1: Remove the dependency between `TestingRemoteS3Facade` and `ManagedS3MockContainer`:**

The `Testing*` classes (this one and `TestingCredentialsController`) should be agnostic to the implementation and seem designed to provide a way to merely tap into the logic of what the proxy is doing. As such, I think the previous flow of having a `TestingRemoteS3Facade` that calls a delegate is nice.

We can implement the logic to connect this to our `ManagedS3MockContainer` by creating a new module that gets these injected

**2: Stop `TestingS3ClientProvider` from setting up new credentials:**

`TestingS3ClientProvider` was creating a random `emulated` credential and adding it to the credential controller every time it was called. This was IMHO somewhat confusing as we were already adding a credentials pair (emulated & real) on test setup, which were never used.

**3: Clarify what happens on the `TestingTrinoS3ProxyServer.Builder`**

The Builder had a way to add users, yet they were only really added to the instantiated TestingTrinoS3ProxyServer instance. I feel that this is misleading - if the testing server is able to have the list of users changed at runtime (which is nice), then forcing users to do this via the builder feels clunky.

**4: Centralise constants**