### PR TITLE
Support serving of Virtual Host requests

### DIFF
--- a/trino-s3-proxy/pom.xml
+++ b/trino-s3-proxy/pom.xml
@@ -95,6 +95,11 @@
         </dependency>
 
         <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>

--- a/trino-s3-proxy/src/main/java/io/trino/s3/proxy/server/TrinoS3ProxyServerModule.java
+++ b/trino-s3-proxy/src/main/java/io/trino/s3/proxy/server/TrinoS3ProxyServerModule.java
@@ -25,6 +25,7 @@ import io.trino.s3.proxy.server.remote.RemoteS3Facade;
 import io.trino.s3.proxy.server.remote.VirtualHostStyleRemoteS3Facade;
 import io.trino.s3.proxy.server.rest.TrinoS3ProxyClient;
 import io.trino.s3.proxy.server.rest.TrinoS3ProxyClient.ForProxyClient;
+import io.trino.s3.proxy.server.rest.TrinoS3ProxyConfig;
 import io.trino.s3.proxy.server.rest.TrinoS3ProxyResource;
 import io.trino.s3.proxy.server.rest.TrinoStsResource;
 
@@ -45,7 +46,7 @@ public class TrinoS3ProxyServerModule
         jaxrsBinder(binder).bind(TrinoStsResource.class);
 
         configBinder(binder).bindConfig(SigningControllerConfig.class);
-
+        configBinder(binder).bindConfig(TrinoS3ProxyConfig.class);
         binder.bind(SigningController.class).in(Scopes.SINGLETON);
         binder.bind(CredentialsController.class).in(Scopes.SINGLETON);
 

--- a/trino-s3-proxy/src/main/java/io/trino/s3/proxy/server/collections/MultiMapHelper.java
+++ b/trino-s3-proxy/src/main/java/io/trino/s3/proxy/server/collections/MultiMapHelper.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.s3.proxy.server.collections;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.function.BiFunction;
+
+public class MultiMapHelper
+{
+    public static <V> MultivaluedMap<String, V> lowercase(MultivaluedMap<String, V> map)
+    {
+        return lowercase(map, (ignored, values) -> values);
+    }
+
+    public static <V> MultivaluedMap<String, V> lowercase(MultivaluedMap<String, V> map, BiFunction<String, List<V>, List<V>> valueMapper)
+    {
+        MultivaluedMap<String, V> result = new MultivaluedHashMap<>();
+        map.forEach((name, values) -> result.put(name.toLowerCase(Locale.ROOT), valueMapper.apply(name.toLowerCase(Locale.ROOT), values)));
+        return result;
+    }
+
+    private MultiMapHelper() {}
+}

--- a/trino-s3-proxy/src/main/java/io/trino/s3/proxy/server/rest/ParsedS3Request.java
+++ b/trino-s3-proxy/src/main/java/io/trino/s3/proxy/server/rest/ParsedS3Request.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.s3.proxy.server.rest;
+
+import com.google.common.base.Splitter;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.UriBuilder;
+import org.glassfish.jersey.server.ContainerRequest;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+import static io.trino.s3.proxy.server.collections.MultiMapHelper.lowercase;
+import static java.util.Objects.requireNonNull;
+
+public record ParsedS3Request(
+        String bucketName,
+        String keyInBucket,
+        MultivaluedMap<String, String> requestHeaders,
+        MultivaluedMap<String, String> requestQueryParameters,
+        String httpVerb)
+{
+    public ParsedS3Request
+    {
+        requireNonNull(bucketName, "bucketName is null");
+        requireNonNull(keyInBucket, "keyInBucket is null");
+        requestHeaders = lowercase(requireNonNull(requestHeaders, "requestHeaders is null"));
+        requireNonNull(requestQueryParameters, "requestQueryParameters is null");
+        requireNonNull(httpVerb, "httpVerb is null");
+    }
+
+    public static ParsedS3Request fromRequest(String requestPath, MultivaluedMap<String, String> requestHeaders, MultivaluedMap<String, String> requestQueryParameters, String httpVerb, Optional<String> serverHostName)
+    {
+        MultivaluedMap<String, String> headers = lowercase(requestHeaders);
+        return serverHostName
+                .flatMap(serverHostNameValue -> {
+                    String lowercaseServerHostName = serverHostNameValue.toLowerCase(Locale.ROOT);
+                    return Optional.ofNullable(headers.getFirst("host"))
+                            .map(value -> UriBuilder.fromUri("http://" + value.toLowerCase(Locale.ROOT)).build().getHost())
+                            .filter(value -> value.endsWith(lowercaseServerHostName))
+                            .map(value -> value.substring(0, value.length() - lowercaseServerHostName.length()))
+                            .map(value -> value.endsWith(".") ? value.substring(0, value.length() - 1) : value);
+                })
+                .map(bucket -> new ParsedS3Request(bucket, requestPath, headers, requestQueryParameters, httpVerb))
+                .orElseGet(() -> {
+                    List<String> parts = Splitter.on("/").limit(2).splitToList(requestPath);
+                    if (parts.size() <= 1) {
+                        return new ParsedS3Request(requestPath, "", headers, requestQueryParameters, httpVerb);
+                    }
+                    return new ParsedS3Request(parts.get(0), parts.get(1), headers, requestQueryParameters, httpVerb);
+                });
+    }
+
+    public static ParsedS3Request fromRequest(String requestPath, ContainerRequest request, Optional<String> serverHostName)
+    {
+        return fromRequest(requestPath, request.getHeaders(), request.getUriInfo().getQueryParameters(), request.getMethod(), serverHostName);
+    }
+}

--- a/trino-s3-proxy/src/main/java/io/trino/s3/proxy/server/rest/TrinoS3ProxyConfig.java
+++ b/trino-s3-proxy/src/main/java/io/trino/s3/proxy/server/rest/TrinoS3ProxyConfig.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.s3.proxy.server.rest;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.Optional;
+
+public class TrinoS3ProxyConfig
+{
+    private Optional<String> hostName = Optional.empty();
+
+    @Config("s3proxy.hostname")
+    @ConfigDescription("Hostname to use for REST operations, virtual-host style addressing is only supported if this is set")
+    public TrinoS3ProxyConfig setHostName(String hostName)
+    {
+        this.hostName = Optional.ofNullable(hostName);
+        return this;
+    }
+
+    @NotNull
+    public Optional<String> getHostName()
+    {
+        return hostName;
+    }
+}

--- a/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/TestProxiedAssumedRoleRequests.java
+++ b/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/TestProxiedAssumedRoleRequests.java
@@ -37,7 +37,7 @@ import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@TrinoS3ProxyTest(modules = WithConfiguredBuckets.class)
+@TrinoS3ProxyTest(filters = WithConfiguredBuckets.class)
 public class TestProxiedAssumedRoleRequests
         extends AbstractTestProxiedRequests
 {

--- a/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/TestProxiedRequestsToVirtualHostEndpoint.java
+++ b/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/TestProxiedRequestsToVirtualHostEndpoint.java
@@ -22,7 +22,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 
 import java.util.List;
 
-@TrinoS3ProxyTest(modules = {WithConfiguredBuckets.class, WithVirtualHostAddressing.class})
+@TrinoS3ProxyTest(filters = {WithConfiguredBuckets.class, WithVirtualHostAddressing.class})
 public class TestProxiedRequestsToVirtualHostEndpoint
         extends AbstractTestProxiedRequests
 {

--- a/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/TestProxiedRequestsWithVirtualHostProxy.java
+++ b/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/TestProxiedRequestsWithVirtualHostProxy.java
@@ -17,16 +17,17 @@ import com.google.inject.Inject;
 import io.trino.s3.proxy.server.testing.ManagedS3MockContainer.ForS3MockContainer;
 import io.trino.s3.proxy.server.testing.harness.TrinoS3ProxyTest;
 import io.trino.s3.proxy.server.testing.harness.TrinoS3ProxyTestCommonModules.WithConfiguredBuckets;
+import io.trino.s3.proxy.server.testing.harness.TrinoS3ProxyTestCommonModules.WithVirtualHostEnabledProxy;
 import software.amazon.awssdk.services.s3.S3Client;
 
 import java.util.List;
 
-@TrinoS3ProxyTest(filters = WithConfiguredBuckets.class)
-public class TestProxiedRequests
+@TrinoS3ProxyTest(filters = {WithConfiguredBuckets.class, WithVirtualHostEnabledProxy.class, WithVirtualHostEnabledProxy.class})
+public class TestProxiedRequestsWithVirtualHostProxy
         extends AbstractTestProxiedRequests
 {
     @Inject
-    public TestProxiedRequests(S3Client s3Client, @ForS3MockContainer S3Client storageClient, @ForS3MockContainer List<String> configuredBuckets)
+    public TestProxiedRequestsWithVirtualHostProxy(S3Client s3Client, @ForS3MockContainer S3Client storageClient, @ForS3MockContainer List<String> configuredBuckets)
     {
         super(s3Client, storageClient, configuredBuckets);
     }

--- a/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/TestRemoteSessionProxiedRequests.java
+++ b/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/TestRemoteSessionProxiedRequests.java
@@ -27,7 +27,7 @@ import java.util.List;
 
 import static io.trino.s3.proxy.server.testing.TestingUtil.clientBuilder;
 
-@TrinoS3ProxyTest(modules = TrinoS3ProxyTestCommonModules.WithConfiguredBuckets.class)
+@TrinoS3ProxyTest(filters = TrinoS3ProxyTestCommonModules.WithConfiguredBuckets.class)
 public class TestRemoteSessionProxiedRequests
         extends AbstractTestProxiedRequests
 {
@@ -41,7 +41,7 @@ public class TestRemoteSessionProxiedRequests
     {
         AwsBasicCredentials awsBasicCredentials = AwsBasicCredentials.create(credentials.emulated().accessKey(), credentials.emulated().secretKey());
 
-        return clientBuilder(httpServer)
+        return clientBuilder(httpServer.getBaseUrl())
                 .credentialsProvider(() -> awsBasicCredentials)
                 .build();
     }

--- a/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/credentials/TestAssumingRoles.java
+++ b/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/credentials/TestAssumingRoles.java
@@ -62,7 +62,7 @@ public class TestAssumingRoles
         EmulatedAssumedRole emulatedAssumedRole = credentialsController.assumeEmulatedRole(testingCredentials.emulated(), "us-east-1", ARN, Optional.empty(), Optional.empty(), Optional.empty())
                 .orElseThrow(() -> new RuntimeException("Failed to assume role"));
 
-        try (S3Client client = clientBuilder(httpServer)
+        try (S3Client client = clientBuilder(httpServer.getBaseUrl())
                 .credentialsProvider(() -> AwsSessionCredentials.create(emulatedAssumedRole.credential().accessKey(), emulatedAssumedRole.credential().secretKey(), emulatedAssumedRole.session()))
                 .build()) {
             // valid assumed role session - should work

--- a/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/testing/TestingUtil.java
+++ b/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/testing/TestingUtil.java
@@ -14,7 +14,6 @@
 package io.trino.s3.proxy.server.testing;
 
 import com.google.inject.BindingAnnotation;
-import io.airlift.http.server.testing.TestingHttpServer;
 import io.trino.s3.proxy.server.credentials.Credential;
 import io.trino.s3.proxy.server.credentials.Credentials;
 import io.trino.s3.proxy.server.rest.TrinoS3ProxyRestConstants;
@@ -46,9 +45,8 @@ public final class TestingUtil
     @BindingAnnotation
     public @interface ForTesting {}
 
-    public static S3ClientBuilder clientBuilder(TestingHttpServer httpServer)
+    public static S3ClientBuilder clientBuilder(URI baseUrl)
     {
-        URI baseUrl = httpServer.getBaseUrl();
         URI localProxyServerUri = baseUrl.resolve(TrinoS3ProxyRestConstants.S3_PATH);
 
         return S3Client.builder()

--- a/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/testing/harness/TrinoS3ProxyTest.java
+++ b/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/testing/harness/TrinoS3ProxyTest.java
@@ -13,7 +13,6 @@
  */
 package io.trino.s3.proxy.server.testing.harness;
 
-import com.google.inject.Module;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -32,7 +31,5 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public @interface TrinoS3ProxyTest
 {
-    Class<? extends Module>[] modules() default {};
-
     Class<? extends BuilderFilter>[] filters() default {};
 }

--- a/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/testing/harness/TrinoS3ProxyTestExtension.java
+++ b/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/testing/harness/TrinoS3ProxyTestExtension.java
@@ -22,6 +22,7 @@ import io.trino.s3.proxy.server.testing.ContainerS3Facade;
 import io.trino.s3.proxy.server.testing.ManagedS3MockContainer;
 import io.trino.s3.proxy.server.testing.ManagedS3MockContainer.ForS3MockContainer;
 import io.trino.s3.proxy.server.testing.TestingS3ClientProvider;
+import io.trino.s3.proxy.server.testing.TestingS3ClientProvider.ForS3ClientProvider;
 import io.trino.s3.proxy.server.testing.TestingTrinoS3ProxyServer;
 import io.trino.s3.proxy.server.testing.TestingUtil.ForTesting;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -53,10 +54,6 @@ public class TrinoS3ProxyTestExtension
 
         TestingTrinoS3ProxyServer.Builder builder = TestingTrinoS3ProxyServer.builder();
 
-        Stream.of(trinoS3ProxyTest.modules())
-                .map(TrinoS3ProxyTestExtension::instantiateModule)
-                .forEach(builder::addModule);
-
         List<BuilderFilter> filters = Stream.of(trinoS3ProxyTest.filters())
                 .map(TrinoS3ProxyTestExtension::instantiateBuilderFilter)
                 .collect(toImmutableList());
@@ -67,6 +64,7 @@ public class TrinoS3ProxyTestExtension
         TestingTrinoS3ProxyServer trinoS3ProxyServer = builder
                 .withMockS3Container()
                 .addModule(binder -> {
+                    newOptionalBinder(binder, Key.get(String.class, ForS3ClientProvider.class));
                     binder.bind(S3Client.class).annotatedWith(ForS3MockContainer.class).toProvider(ManagedS3MockContainer.class);
                     newOptionalBinder(binder, Key.get(RemoteS3Facade.class, ForTesting.class))
                             .setDefault()


### PR DESCRIPTION
Closes #19 

This PR also goes slightly into #37 , by creating an `S3RequestInformation` record - if @ragnard and @mosiac1 are happy with this choice, I'm glad to add the remaining fields and make the signer use it too.