### PR TITLE
Support legacy signing

### DIFF
--- a/trino-s3-proxy/pom.xml
+++ b/trino-s3-proxy/pom.xml
@@ -121,6 +121,11 @@
 
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
+            <artifactId>annotations</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
             <artifactId>auth</artifactId>
         </dependency>
 
@@ -152,6 +157,11 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sts</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>utils</artifactId>
         </dependency>
 
         <dependency>
@@ -193,6 +203,28 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <licenseSets>
+                        <licenseSet>
+                            <excludes combine.children="append">
+                                <exclude>**/software/amazon/awssdk/auth/signer/internal/*</exclude>
+                            </excludes>
+                        </licenseSet>
+                    </licenseSets>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <configuration>
+                    <excludes>**/software/amazon/awssdk/auth/signer/internal/*</excludes>
+                </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>

--- a/trino-s3-proxy/src/main/java/io/trino/s3/proxy/server/credentials/ParsedAuthorization.java
+++ b/trino-s3-proxy/src/main/java/io/trino/s3/proxy/server/credentials/ParsedAuthorization.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.s3.proxy.server.credentials;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import jakarta.annotation.Nullable;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.Objects.requireNonNull;
+
+record ParsedAuthorization(String authorization, Credential credential, Set<String> signedHeaders, String signature)
+{
+    ParsedAuthorization
+    {
+        signedHeaders = ImmutableSet.copyOf(signedHeaders);
+        requireNonNull(signature, "signature is null");
+    }
+
+    record Credential(String accessKey, String region)
+    {
+        Credential
+        {
+            requireNonNull(accessKey, "accessKey is null");
+            requireNonNull(region, "region is null");
+        }
+    }
+
+    boolean isValid()
+    {
+        return !signedHeaders.isEmpty() && !signature.isEmpty() && !credential.accessKey().isEmpty() && !credential.region().isEmpty();
+    }
+
+    static ParsedAuthorization parse(@Nullable String authorization)
+    {
+        if (authorization == null) {
+            return new ParsedAuthorization("", new Credential("", ""), ImmutableSet.of(), "");
+        }
+
+        Map<String, String> parts;
+        try {
+            parts = Splitter.on(',').omitEmptyStrings().trimResults().withKeyValueSeparator('=').split(authorization);
+        }
+        catch (IllegalArgumentException _) {
+            parts = ImmutableMap.of();
+        }
+
+        String credentialSpec = parts.getOrDefault("AWS4-HMAC-SHA256 Credential", "");
+        List<String> credentialList = Splitter.on('/').omitEmptyStrings().trimResults().splitToList(credentialSpec);
+        Credential credential = (credentialList.size() > 2) ? new Credential(credentialList.getFirst(), credentialList.get(2)) : new Credential("", "");
+
+        String signedHeadersSpec = parts.getOrDefault("SignedHeaders", "");
+        Set<String> signedHeaders = Splitter.on(';').omitEmptyStrings().trimResults().splitToStream(signedHeadersSpec).collect(toImmutableSet());
+
+        String signature = parts.getOrDefault("Signature", "");
+
+        return new ParsedAuthorization(authorization, credential, signedHeaders, signature);
+    }
+}

--- a/trino-s3-proxy/src/main/java/io/trino/s3/proxy/server/credentials/Signer.java
+++ b/trino-s3-proxy/src/main/java/io/trino/s3/proxy/server/credentials/Signer.java
@@ -20,6 +20,7 @@ import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.signer.internal.AbstractAwsS3V4Signer;
+import software.amazon.awssdk.auth.signer.internal.CopiedAbstractAwsS3V4Signer;
 import software.amazon.awssdk.auth.signer.params.AwsS3V4SignerParams;
 import software.amazon.awssdk.core.checksums.SdkChecksum;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
@@ -53,18 +54,29 @@ final class Signer
 
     private static final String OVERRIDE_CONTENT_HASH = "__TRINO__OVERRIDE_CONTENT_HASH__";
 
-    private static final Set<String> IGNORED_HEADERS = ImmutableSet.of(
+    private static final Set<String> BASE_IGNORED_HEADERS = ImmutableSet.of(
             "x-amz-decoded-content-length",
             "x-amzn-trace-id",
             "expect",
             "accept-encoding",
             "authorization",
-            "user-agent",
             "connection");
+
+    private static final Set<String> LEGACY_IGNORED_HEADERS = BASE_IGNORED_HEADERS;
+    private static final Set<String> IGNORED_HEADERS = ImmutableSet.<String>builder().addAll(BASE_IGNORED_HEADERS).add("user-agent").build();
 
     private static final Set<String> LOWERCASE_HEADERS = ImmutableSet.of("content-type");
 
     private static final AbstractAwsS3V4Signer aws4Signer = new AbstractAwsS3V4Signer()
+    {
+        @Override
+        protected String calculateContentHash(SdkHttpFullRequest.Builder mutableRequest, AwsS3V4SignerParams signerParams, SdkChecksum contentFlexibleChecksum)
+        {
+            return extractOverrideContentHash(mutableRequest).orElseGet(() -> super.calculateContentHash(mutableRequest, signerParams, contentFlexibleChecksum));
+        }
+    };
+
+    private static final CopiedAbstractAwsS3V4Signer legacyAws4Signer = new CopiedAbstractAwsS3V4Signer()
     {
         @Override
         protected String calculateContentHash(SdkHttpFullRequest.Builder mutableRequest, AwsS3V4SignerParams signerParams, SdkChecksum contentFlexibleChecksum)
@@ -86,6 +98,8 @@ final class Signer
 
     static String sign(
             SigningController.Mode mode,
+            boolean isLegacy,
+            boolean signatureHasContentLength,
             String serviceName,
             URI requestURI,
             MultivaluedMap<String, String> requestHeaders,
@@ -113,10 +127,12 @@ final class Signer
 
         entity.ifPresent(entityBytes -> requestBuilder.contentStreamProvider(() -> new ByteArrayInputStream(entityBytes)));
 
+        Set<String> ignoredHeaders = isLegacy ? LEGACY_IGNORED_HEADERS : IGNORED_HEADERS;
         requestHeaders
                 .entrySet()
                 .stream()
-                .filter(entry -> !IGNORED_HEADERS.contains(entry.getKey()))
+                .filter(entry -> !ignoredHeaders.contains(entry.getKey()))
+                .filter(entry -> !entry.getKey().equals("content-length") || signatureHasContentLength)
                 .forEach(entry -> entry.getValue().forEach(value -> requestBuilder.appendHeader(entry.getKey(), value)));
 
         queryParameters.forEach(requestBuilder::putRawQueryParameter);
@@ -171,7 +187,10 @@ final class Signer
         Clock clock = Clock.fixed(zonedRequestDateTime.toInstant(), zonedRequestDateTime.getZone());
         signerParamsBuilder.signingClockOverride(clock);
 
-        return aws4Signer.sign(requestBuilder.build(), signerParamsBuilder.build()).firstMatchingHeader("Authorization").orElseThrow(() -> {
+        BiFunction<SdkHttpFullRequest, AwsS3V4SignerParams, SdkHttpFullRequest> signingProc = isLegacy ? legacyAws4Signer::sign : aws4Signer::sign;
+        SdkHttpFullRequest signedRequest = signingProc.apply(requestBuilder.build(), signerParamsBuilder.build());
+
+        return signedRequest.firstMatchingHeader("Authorization").orElseThrow(() -> {
             log.debug("Signer did not generate \"Authorization\" header");
             return new WebApplicationException(Response.Status.BAD_REQUEST);
         });

--- a/trino-s3-proxy/src/main/java/io/trino/s3/proxy/server/credentials/SigningController.java
+++ b/trino-s3-proxy/src/main/java/io/trino/s3/proxy/server/credentials/SigningController.java
@@ -13,7 +13,6 @@
  */
 package io.trino.s3.proxy.server.credentials;
 
-import com.google.common.base.Splitter;
 import com.google.inject.Inject;
 import io.trino.s3.proxy.server.rest.Request;
 import jakarta.ws.rs.WebApplicationException;
@@ -23,7 +22,6 @@ import jakarta.ws.rs.core.Response;
 import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -131,36 +129,16 @@ public class SigningController
             String httpMethod,
             Optional<byte[]> entity)
     {
-        String authorization = requestHeaders.getFirst("Authorization");
-        if (authorization == null) {
+        ParsedAuthorization parsedAuthorization = ParsedAuthorization.parse(requestHeaders.getFirst("Authorization"));
+        if (!parsedAuthorization.isValid()) {
             return Optional.empty();
         }
-
-        List<String> authorizationParts = Splitter.on(",").trimResults().splitToList(authorization);
-        if (authorizationParts.isEmpty()) {
-            return Optional.empty();
-        }
-
-        String credential = authorizationParts.getFirst();
-        List<String> credentialParts = Splitter.on("=").splitToList(credential);
-        if (credentialParts.size() < 2) {
-            return Optional.empty();
-        }
-
-        String credentialValue = credentialParts.get(1);
-        List<String> credentialValueParts = Splitter.on("/").splitToList(credentialValue);
-        if (credentialValueParts.size() < 3) {
-            return Optional.empty();
-        }
-
-        String emulatedAccessKey = credentialValueParts.getFirst();
-        String region = credentialValueParts.get(2);
 
         Optional<String> session = Optional.ofNullable(requestHeaders.getFirst("x-amz-security-token"));
 
-        return credentialsController.withCredentials(emulatedAccessKey, session, credentials -> {
-            SigningMetadata metadata = new SigningMetadata(signingServiceType, credentials, session, region);
-            if (isValidAuthorization(metadata, credentialsSupplier, authorization, requestURI, requestHeaders, queryParameters, httpMethod, entity)) {
+        return credentialsController.withCredentials(parsedAuthorization.credential().accessKey(), session, credentials -> {
+            SigningMetadata metadata = new SigningMetadata(signingServiceType, credentials, session, parsedAuthorization.credential().region());
+            if (isValidAuthorization(metadata, credentialsSupplier, parsedAuthorization.authorization(), requestURI, requestHeaders, queryParameters, httpMethod, entity)) {
                 return Optional.of(metadata);
             }
             return Optional.empty();

--- a/trino-s3-proxy/src/main/java/software/amazon/awssdk/auth/signer/internal/CopiedAbstractAws4Signer.java
+++ b/trino-s3-proxy/src/main/java/software/amazon/awssdk/auth/signer/internal/CopiedAbstractAws4Signer.java
@@ -1,0 +1,706 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.auth.signer.internal;
+
+import static software.amazon.awssdk.auth.signer.Aws4UnsignedPayloadSigner.UNSIGNED_PAYLOAD;
+import static software.amazon.awssdk.core.interceptor.SdkExecutionAttribute.RESOLVED_CHECKSUM_SPECS;
+import static software.amazon.awssdk.utils.StringUtils.lowerCase;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.signer.Aws4Signer;
+import software.amazon.awssdk.auth.signer.AwsSignerExecutionAttribute;
+import software.amazon.awssdk.auth.signer.params.Aws4PresignerParams;
+import software.amazon.awssdk.auth.signer.params.Aws4SignerParams;
+import software.amazon.awssdk.auth.signer.params.SignerChecksumParams;
+import software.amazon.awssdk.core.checksums.ChecksumSpecs;
+import software.amazon.awssdk.core.checksums.SdkChecksum;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.internal.util.HttpChecksumUtils;
+import software.amazon.awssdk.core.signer.Presigner;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpRequest;
+import software.amazon.awssdk.utils.BinaryUtils;
+import software.amazon.awssdk.utils.Logger;
+import software.amazon.awssdk.utils.Pair;
+import software.amazon.awssdk.utils.StringUtils;
+import software.amazon.awssdk.utils.http.SdkHttpUtils;
+
+/**
+ * Abstract base class for the AWS SigV4 signer implementations.
+ * @param <T> Type of the signing params class that is used for signing the request
+ * @param <U> Type of the signing params class that is used for pre signing the request
+ */
+@SdkInternalApi
+public abstract class CopiedAbstractAws4Signer<T extends Aws4SignerParams, U extends Aws4PresignerParams>
+    extends AbstractAwsSigner implements Presigner {
+
+    public static final String EMPTY_STRING_SHA256_HEX = BinaryUtils.toHex(hash(""));
+
+    private static final Logger LOG = Logger.loggerFor(Aws4Signer.class);
+    private static final int SIGNER_CACHE_MAX_SIZE = 300;
+    private static final FifoCache<SignerKey> SIGNER_CACHE =
+        new FifoCache<>(SIGNER_CACHE_MAX_SIZE);
+    // ONLY CODE CHANGE - remove user-agent from ignored headers
+    private static final List<String> LIST_OF_HEADERS_TO_IGNORE_IN_LOWER_CASE =
+        Arrays.asList("connection", "x-amzn-trace-id", "expect");
+
+    protected SdkHttpFullRequest.Builder doSign(SdkHttpFullRequest request,
+                                                Aws4SignerRequestParams requestParams,
+                                                T signingParams) {
+        SdkHttpFullRequest.Builder mutableRequest = request.toBuilder();
+        SdkChecksum sdkChecksum = createSdkChecksumFromParams(signingParams, request);
+        String contentHash = calculateContentHash(mutableRequest, signingParams, sdkChecksum);
+        return doSign(mutableRequest.build(), requestParams, signingParams,
+                new ContentChecksum(contentHash, sdkChecksum));
+    }
+
+    protected SdkHttpFullRequest.Builder doSign(SdkHttpFullRequest request,
+                                                Aws4SignerRequestParams requestParams,
+                                                T signingParams,
+                                                ContentChecksum contentChecksum) {
+
+        SdkHttpFullRequest.Builder mutableRequest = request.toBuilder();
+
+        AwsCredentials sanitizedCredentials = sanitizeCredentials(signingParams.awsCredentials());
+        if (sanitizedCredentials instanceof AwsSessionCredentials) {
+            addSessionCredentials(mutableRequest, (AwsSessionCredentials) sanitizedCredentials);
+        }
+
+        addHostHeader(mutableRequest);
+        addDateHeader(mutableRequest, requestParams.getFormattedRequestSigningDateTime());
+
+        mutableRequest.firstMatchingHeader(SignerConstant.X_AMZ_CONTENT_SHA256)
+                      .filter(h -> h.equals("required"))
+                      .ifPresent(h -> mutableRequest.putHeader(
+                              SignerConstant.X_AMZ_CONTENT_SHA256, contentChecksum.contentHash()));
+
+        putChecksumHeader(signingParams.checksumParams(), contentChecksum.contentFlexibleChecksum(),
+                mutableRequest, contentChecksum.contentHash());
+
+        CanonicalRequest canonicalRequest = createCanonicalRequest(request,
+                                                                   mutableRequest,
+                                                                   contentChecksum.contentHash(),
+                                                                   signingParams.doubleUrlEncode(),
+                                                                   signingParams.normalizePath());
+
+        String canonicalRequestString = canonicalRequest.string();
+        String stringToSign = createStringToSign(canonicalRequestString, requestParams);
+
+        byte[] signingKey = deriveSigningKey(sanitizedCredentials, requestParams);
+
+        byte[] signature = computeSignature(stringToSign, signingKey);
+
+        mutableRequest.putHeader(SignerConstant.AUTHORIZATION,
+                                 buildAuthorizationHeader(signature, sanitizedCredentials, requestParams, canonicalRequest));
+
+        processRequestPayload(mutableRequest, signature, signingKey, requestParams, signingParams,
+                contentChecksum.contentFlexibleChecksum());
+
+        return mutableRequest;
+    }
+
+    protected SdkHttpFullRequest.Builder doPresign(SdkHttpFullRequest request,
+                                                   Aws4SignerRequestParams requestParams,
+                                                   U signingParams) {
+
+        SdkHttpFullRequest.Builder mutableRequest = request.toBuilder();
+
+        long expirationInSeconds = getSignatureDurationInSeconds(requestParams, signingParams);
+        addHostHeader(mutableRequest);
+
+        AwsCredentials sanitizedCredentials = sanitizeCredentials(signingParams.awsCredentials());
+        if (sanitizedCredentials instanceof AwsSessionCredentials) {
+            // For SigV4 pre-signing URL, we need to add "X-Amz-Security-Token"
+            // as a query string parameter, before constructing the canonical
+            // request.
+            mutableRequest.putRawQueryParameter(SignerConstant.X_AMZ_SECURITY_TOKEN,
+                                                ((AwsSessionCredentials) sanitizedCredentials).sessionToken());
+        }
+
+        // Add the important parameters for v4 signing
+        String contentSha256 = calculateContentHashPresign(mutableRequest, signingParams);
+
+        CanonicalRequest canonicalRequest = createCanonicalRequest(request,
+                                                                   mutableRequest,
+                                                                   contentSha256,
+                                                                   signingParams.doubleUrlEncode(),
+                                                                   signingParams.normalizePath());
+
+        addPreSignInformationToRequest(mutableRequest, canonicalRequest, sanitizedCredentials,
+                                       requestParams, expirationInSeconds);
+
+        String string = canonicalRequest.string();
+        String stringToSign = createStringToSign(string, requestParams);
+
+        byte[] signingKey = deriveSigningKey(sanitizedCredentials, requestParams);
+
+        byte[] signature = computeSignature(stringToSign, signingKey);
+
+        mutableRequest.putRawQueryParameter(SignerConstant.X_AMZ_SIGNATURE, BinaryUtils.toHex(signature));
+
+        return mutableRequest;
+    }
+
+    @Override
+    protected void addSessionCredentials(SdkHttpFullRequest.Builder mutableRequest,
+                                         AwsSessionCredentials credentials) {
+        mutableRequest.putHeader(SignerConstant.X_AMZ_SECURITY_TOKEN, credentials.sessionToken());
+    }
+
+    /**
+     * Calculate the hash of the request's payload. Subclass could override this
+     * method to provide different values for "x-amz-content-sha256" header or
+     * do any other necessary set-ups on the request headers. (e.g. aws-chunked
+     * uses a pre-defined header value, and needs to change some headers
+     * relating to content-encoding and content-length.)
+     */
+    protected String calculateContentHash(SdkHttpFullRequest.Builder mutableRequest, T signerParams) {
+        return calculateContentHash(mutableRequest, signerParams, null);
+    }
+
+
+    /**
+     * This method overloads calculateContentHash with contentFlexibleChecksum.
+     * The contentFlexibleChecksum is computed at the same time while hash is calculated for Content.
+     */
+    protected String calculateContentHash(SdkHttpFullRequest.Builder mutableRequest, T signerParams,
+                                          SdkChecksum contentFlexibleChecksum) {
+        InputStream payloadStream = getBinaryRequestPayloadStream(mutableRequest.contentStreamProvider());
+        return BinaryUtils.toHex(hash(payloadStream, contentFlexibleChecksum));
+    }
+
+    protected abstract void processRequestPayload(SdkHttpFullRequest.Builder mutableRequest,
+                                                  byte[] signature,
+                                                  byte[] signingKey,
+                                                  Aws4SignerRequestParams signerRequestParams,
+                                                  T signerParams);
+
+
+    protected abstract void processRequestPayload(SdkHttpFullRequest.Builder mutableRequest,
+                                                  byte[] signature,
+                                                  byte[] signingKey,
+                                                  Aws4SignerRequestParams signerRequestParams,
+                                                  T signerParams,
+                                                  SdkChecksum sdkChecksum);
+
+    protected abstract String calculateContentHashPresign(SdkHttpFullRequest.Builder mutableRequest, U signerParams);
+
+    /**
+     * Step 3 of the AWS Signature version 4 calculation. It involves deriving
+     * the signing key and computing the signature. Refer to
+     * http://docs.aws.amazon
+     * .com/general/latest/gr/sigv4-calculate-signature.html
+     */
+    protected final byte[] deriveSigningKey(AwsCredentials credentials, Aws4SignerRequestParams signerRequestParams) {
+        return deriveSigningKey(credentials,
+                Instant.ofEpochMilli(signerRequestParams.getRequestSigningDateTimeMilli()),
+                signerRequestParams.getRegionName(),
+                signerRequestParams.getServiceSigningName());
+    }
+
+    protected final byte[] deriveSigningKey(AwsCredentials credentials, Instant signingInstant, String region, String service) {
+        String cacheKey = createSigningCacheKeyName(credentials, region, service);
+        SignerKey signerKey = SIGNER_CACHE.get(cacheKey);
+
+        if (signerKey != null && signerKey.isValidForDate(signingInstant)) {
+            return signerKey.getSigningKey();
+        }
+
+        LOG.trace(() -> "Generating a new signing key as the signing key not available in the cache for the date: " +
+                signingInstant.toEpochMilli());
+        byte[] signingKey = newSigningKey(credentials,
+                Aws4SignerUtils.formatDateStamp(signingInstant),
+                region,
+                service);
+        SIGNER_CACHE.add(cacheKey, new SignerKey(signingInstant, signingKey));
+        return signingKey;
+    }
+
+    /**
+     * Step 1 of the AWS Signature version 4 calculation. Refer to
+     * http://docs.aws
+     * .amazon.com/general/latest/gr/sigv4-create-canonical-request.html to
+     * generate the canonical request.
+     */
+    private CanonicalRequest createCanonicalRequest(SdkHttpFullRequest request,
+                                                    SdkHttpFullRequest.Builder requestBuilder,
+                                                    String contentSha256,
+                                                    boolean doubleUrlEncode,
+                                                    boolean normalizePath) {
+        return new CanonicalRequest(request, requestBuilder, contentSha256, doubleUrlEncode, normalizePath);
+    }
+
+    /**
+     * Step 2 of the AWS Signature version 4 calculation. Refer to
+     * http://docs.aws
+     * .amazon.com/general/latest/gr/sigv4-create-string-to-sign.html.
+     */
+    private String createStringToSign(String canonicalRequest,
+                                      Aws4SignerRequestParams requestParams) {
+
+        LOG.debug(() -> "AWS4 Canonical Request: " + canonicalRequest);
+
+        String requestHash = BinaryUtils.toHex(hash(canonicalRequest));
+
+        String stringToSign = requestParams.getSigningAlgorithm() +
+                              SignerConstant.LINE_SEPARATOR +
+                              requestParams.getFormattedRequestSigningDateTime() +
+                              SignerConstant.LINE_SEPARATOR +
+                              requestParams.getScope() +
+                              SignerConstant.LINE_SEPARATOR +
+                              requestHash;
+
+        LOG.debug(() -> "AWS4 String to sign: " + stringToSign);
+        return stringToSign;
+    }
+
+    private String createSigningCacheKeyName(AwsCredentials credentials,
+                                             String regionName,
+                                             String serviceName) {
+        return credentials.secretAccessKey() + "-" + regionName + "-" + serviceName;
+    }
+
+    /**
+     * Step 3 of the AWS Signature version 4 calculation. It involves deriving
+     * the signing key and computing the signature. Refer to
+     * http://docs.aws.amazon
+     * .com/general/latest/gr/sigv4-calculate-signature.html
+     */
+    private byte[] computeSignature(String stringToSign, byte[] signingKey) {
+        return sign(stringToSign.getBytes(StandardCharsets.UTF_8), signingKey,
+                    SigningAlgorithm.HmacSHA256);
+    }
+
+    /**
+     * Creates the authorization header to be included in the request.
+     */
+    private String buildAuthorizationHeader(byte[] signature,
+                                            AwsCredentials credentials,
+                                            Aws4SignerRequestParams signerParams,
+                                            CanonicalRequest canonicalRequest) {
+        String accessKeyId = credentials.accessKeyId();
+        String scope = signerParams.getScope();
+        StringBuilder stringBuilder = canonicalRequest.signedHeaderStringBuilder();
+        String signatureHex = BinaryUtils.toHex(signature);
+        return SignerConstant.AWS4_SIGNING_ALGORITHM
+               + " Credential="
+               + accessKeyId
+               + "/"
+               + scope
+               + ", SignedHeaders="
+               + stringBuilder
+               + ", Signature="
+               + signatureHex;
+    }
+
+    /**
+     * Includes all the signing headers as request parameters for pre-signing.
+     */
+    private void addPreSignInformationToRequest(SdkHttpFullRequest.Builder mutableRequest,
+                                                CanonicalRequest canonicalRequest,
+                                                AwsCredentials sanitizedCredentials,
+                                                Aws4SignerRequestParams signerParams,
+                                                long expirationInSeconds) {
+
+        String signingCredentials = sanitizedCredentials.accessKeyId() + "/" + signerParams.getScope();
+
+        mutableRequest.putRawQueryParameter(SignerConstant.X_AMZ_ALGORITHM, SignerConstant.AWS4_SIGNING_ALGORITHM);
+        mutableRequest.putRawQueryParameter(SignerConstant.X_AMZ_DATE, signerParams.getFormattedRequestSigningDateTime());
+        mutableRequest.putRawQueryParameter(SignerConstant.X_AMZ_SIGNED_HEADER, canonicalRequest.signedHeaderString());
+        mutableRequest.putRawQueryParameter(SignerConstant.X_AMZ_EXPIRES, Long.toString(expirationInSeconds));
+        mutableRequest.putRawQueryParameter(SignerConstant.X_AMZ_CREDENTIAL, signingCredentials);
+    }
+
+    /**
+     * Tests a char to see if is it whitespace.
+     * This method considers the same characters to be white
+     * space as the Pattern class does when matching \s
+     *
+     * @param ch the character to be tested
+     * @return true if the character is white  space, false otherwise.
+     */
+    private static boolean isWhiteSpace(char ch) {
+        return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\u000b' || ch == '\r' || ch == '\f';
+    }
+
+    private void addHostHeader(SdkHttpFullRequest.Builder mutableRequest) {
+        // AWS4 requires that we sign the Host header so we
+        // have to have it in the request by the time we sign.
+
+        StringBuilder hostHeaderBuilder = new StringBuilder(mutableRequest.host());
+        if (!SdkHttpUtils.isUsingStandardPort(mutableRequest.protocol(), mutableRequest.port())) {
+            hostHeaderBuilder.append(":").append(mutableRequest.port());
+        }
+
+        mutableRequest.putHeader(SignerConstant.HOST, hostHeaderBuilder.toString());
+    }
+
+    private void addDateHeader(SdkHttpFullRequest.Builder mutableRequest, String dateTime) {
+        mutableRequest.putHeader(SignerConstant.X_AMZ_DATE, dateTime);
+    }
+
+    /**
+     * Generates an expiration time for the presigned url. If user has specified
+     * an expiration time, check if it is in the given limit.
+     */
+    private long getSignatureDurationInSeconds(Aws4SignerRequestParams requestParams,
+                                               U signingParams) {
+
+        long expirationInSeconds = signingParams.expirationTime()
+                                                .map(t -> t.getEpochSecond() -
+                                                          (requestParams.getRequestSigningDateTimeMilli() / 1000))
+                                                .orElse(SignerConstant.PRESIGN_URL_MAX_EXPIRATION_SECONDS);
+
+        if (expirationInSeconds > SignerConstant.PRESIGN_URL_MAX_EXPIRATION_SECONDS) {
+            throw SdkClientException.builder()
+                                    .message("Requests that are pre-signed by SigV4 algorithm are valid for at most 7" +
+                                             " days. The expiration date set on the current request [" +
+                                             Aws4SignerUtils.formatTimestamp(expirationInSeconds * 1000L) + "] +" +
+                                            " has exceeded this limit.")
+                                    .build();
+        }
+        return expirationInSeconds;
+    }
+
+    /**
+     * Generates a new signing key from the given parameters and returns it.
+     */
+    private byte[] newSigningKey(AwsCredentials credentials,
+                                 String dateStamp, String regionName, String serviceName) {
+        byte[] kSecret = ("AWS4" + credentials.secretAccessKey())
+            .getBytes(StandardCharsets.UTF_8);
+        byte[] kDate = sign(dateStamp, kSecret, SigningAlgorithm.HmacSHA256);
+        byte[] kRegion = sign(regionName, kDate, SigningAlgorithm.HmacSHA256);
+        byte[] kService = sign(serviceName, kRegion,
+                               SigningAlgorithm.HmacSHA256);
+        return sign(SignerConstant.AWS4_TERMINATOR, kService, SigningAlgorithm.HmacSHA256);
+    }
+
+    protected <B extends Aws4PresignerParams.Builder> B extractPresignerParams(B builder,
+                                                                               ExecutionAttributes executionAttributes) {
+        builder = extractSignerParams(builder, executionAttributes);
+        builder.expirationTime(executionAttributes.getAttribute(AwsSignerExecutionAttribute.PRESIGNER_EXPIRATION));
+
+        return builder;
+    }
+
+    protected <B extends Aws4SignerParams.Builder> B extractSignerParams(B paramsBuilder,
+                                                                         ExecutionAttributes executionAttributes) {
+        paramsBuilder.awsCredentials(executionAttributes.getAttribute(AwsSignerExecutionAttribute.AWS_CREDENTIALS))
+                     .signingName(executionAttributes.getAttribute(AwsSignerExecutionAttribute.SERVICE_SIGNING_NAME))
+                     .signingRegion(executionAttributes.getAttribute(AwsSignerExecutionAttribute.SIGNING_REGION))
+                     .timeOffset(executionAttributes.getAttribute(AwsSignerExecutionAttribute.TIME_OFFSET))
+                     .signingClockOverride(executionAttributes.getAttribute(AwsSignerExecutionAttribute.SIGNING_CLOCK));
+
+        Boolean doubleUrlEncode = executionAttributes.getAttribute(AwsSignerExecutionAttribute.SIGNER_DOUBLE_URL_ENCODE);
+        if (doubleUrlEncode != null) {
+            paramsBuilder.doubleUrlEncode(doubleUrlEncode);
+        }
+
+        Boolean normalizePath =
+            executionAttributes.getAttribute(AwsSignerExecutionAttribute.SIGNER_NORMALIZE_PATH);
+        if (normalizePath != null) {
+            paramsBuilder.normalizePath(normalizePath);
+        }
+        ChecksumSpecs checksumSpecs = executionAttributes.getAttribute(RESOLVED_CHECKSUM_SPECS);
+        if (checksumSpecs != null && checksumSpecs.algorithm() != null) {
+            paramsBuilder.checksumParams(buildSignerChecksumParams(checksumSpecs));
+        }
+        return paramsBuilder;
+    }
+
+    private void putChecksumHeader(SignerChecksumParams checksumSigner, SdkChecksum sdkChecksum,
+                                   SdkHttpFullRequest.Builder mutableRequest, String contentHashString) {
+
+        if (checksumSigner != null && sdkChecksum != null && !UNSIGNED_PAYLOAD.equals(contentHashString)
+            && !"STREAMING-UNSIGNED-PAYLOAD-TRAILER".equals(contentHashString)) {
+
+            if (HttpChecksumUtils.isHttpChecksumPresent(mutableRequest.build(),
+                                                        ChecksumSpecs.builder()
+                                                                     .headerName(checksumSigner.checksumHeaderName()).build())) {
+                LOG.debug(() -> "Checksum already added in header ");
+                return;
+            }
+            String headerChecksum = checksumSigner.checksumHeaderName();
+            if (StringUtils.isNotBlank(headerChecksum)) {
+                mutableRequest.putHeader(headerChecksum,
+                                         BinaryUtils.toBase64(sdkChecksum.getChecksumBytes()));
+            }
+        }
+    }
+
+    private SignerChecksumParams buildSignerChecksumParams(ChecksumSpecs checksumSpecs) {
+        return SignerChecksumParams.builder().algorithm(checksumSpecs.algorithm())
+                                   .isStreamingRequest(checksumSpecs.isRequestStreaming())
+                                   .checksumHeaderName(checksumSpecs.headerName())
+                                   .build();
+    }
+
+    private SdkChecksum createSdkChecksumFromParams(T signingParams, SdkHttpFullRequest request) {
+        SignerChecksumParams signerChecksumParams = signingParams.checksumParams();
+        boolean isValidChecksumHeader =
+            signerChecksumParams != null && StringUtils.isNotBlank(signerChecksumParams.checksumHeaderName());
+
+        if (isValidChecksumHeader
+            && !HttpChecksumUtils.isHttpChecksumPresent(
+            request,
+            ChecksumSpecs.builder().headerName(signerChecksumParams.checksumHeaderName()).build())) {
+            return SdkChecksum.forAlgorithm(signerChecksumParams.algorithm());
+        }
+        return null;
+    }
+
+    static final class CanonicalRequest {
+        private final SdkHttpFullRequest request;
+        private final SdkHttpFullRequest.Builder requestBuilder;
+        private final String contentSha256;
+        private final boolean doubleUrlEncode;
+        private final boolean normalizePath;
+
+        private String canonicalRequestString;
+        private StringBuilder signedHeaderStringBuilder;
+        private List<Pair<String, List<String>>> canonicalHeaders;
+        private String signedHeaderString;
+
+        CanonicalRequest(SdkHttpFullRequest request,
+                         SdkHttpFullRequest.Builder requestBuilder,
+                         String contentSha256,
+                         boolean doubleUrlEncode,
+                         boolean normalizePath) {
+            this.request = request;
+            this.requestBuilder = requestBuilder;
+            this.contentSha256 = contentSha256;
+            this.doubleUrlEncode = doubleUrlEncode;
+            this.normalizePath = normalizePath;
+        }
+
+        public String string() {
+            if (canonicalRequestString == null) {
+                StringBuilder canonicalRequest = new StringBuilder(512);
+                canonicalRequest.append(requestBuilder.method().toString())
+                                .append(SignerConstant.LINE_SEPARATOR);
+                addCanonicalizedResourcePath(canonicalRequest,
+                                             request,
+                                             doubleUrlEncode,
+                                             normalizePath);
+                canonicalRequest.append(SignerConstant.LINE_SEPARATOR);
+                addCanonicalizedQueryString(canonicalRequest, requestBuilder);
+                canonicalRequest.append(SignerConstant.LINE_SEPARATOR);
+                addCanonicalizedHeaderString(canonicalRequest, canonicalHeaders());
+                canonicalRequest.append(SignerConstant.LINE_SEPARATOR)
+                                .append(signedHeaderStringBuilder())
+                                .append(SignerConstant.LINE_SEPARATOR)
+                                .append(contentSha256);
+                this.canonicalRequestString = canonicalRequest.toString();
+            }
+            return canonicalRequestString;
+        }
+
+        private void addCanonicalizedResourcePath(StringBuilder result,
+                                                  SdkHttpRequest request,
+                                                  boolean urlEncode,
+                                                  boolean normalizePath) {
+            String path = normalizePath ? request.getUri().normalize().getRawPath()
+                                        : request.encodedPath();
+
+            if (StringUtils.isEmpty(path)) {
+                result.append("/");
+                return;
+            }
+
+            if (urlEncode) {
+                path = SdkHttpUtils.urlEncodeIgnoreSlashes(path);
+            }
+
+            if (!path.startsWith("/")) {
+                result.append("/");
+            }
+            result.append(path);
+
+            // Normalization can leave a trailing slash at the end of the resource path,
+            // even if the input path doesn't end with one. Example input: /foo/bar/.
+            // Remove the trailing slash if the input path doesn't end with one.
+            boolean trimTrailingSlash = normalizePath &&
+                                        path.length() > 1 &&
+                                        !request.encodedPath().endsWith("/") &&
+                                        result.charAt(result.length() - 1) == '/';
+            if (trimTrailingSlash) {
+                result.setLength(result.length() - 1);
+            }
+        }
+
+        /**
+         * Examines the specified query string parameters and returns a
+         * canonicalized form.
+         * <p>
+         * The canonicalized query string is formed by first sorting all the query
+         * string parameters, then URI encoding both the key and value and then
+         * joining them, in order, separating key value pairs with an '&amp;'.
+         *
+         * @return A canonicalized form for the specified query string parameters.
+         */
+        private void addCanonicalizedQueryString(StringBuilder result, SdkHttpRequest.Builder httpRequest) {
+
+            SortedMap<String, List<String>> sorted = new TreeMap<>();
+
+            /**
+             * Signing protocol expects the param values also to be sorted after url
+             * encoding in addition to sorted parameter names.
+             */
+            httpRequest.forEachRawQueryParameter((key, values) -> {
+                if (StringUtils.isEmpty(key)) {
+                    // Do not sign empty keys.
+                    return;
+                }
+
+                String encodedParamName = SdkHttpUtils.urlEncode(key);
+
+                List<String> encodedValues = new ArrayList<>(values.size());
+                for (String value : values) {
+                    String encodedValue = SdkHttpUtils.urlEncode(value);
+
+                    // Null values should be treated as empty for the purposes of signing, not missing.
+                    // For example "?foo=" instead of "?foo".
+                    String signatureFormattedEncodedValue = encodedValue == null ? "" : encodedValue;
+
+                    encodedValues.add(signatureFormattedEncodedValue);
+                }
+                Collections.sort(encodedValues);
+                sorted.put(encodedParamName, encodedValues);
+            });
+
+            SdkHttpUtils.flattenQueryParameters(result, sorted);
+        }
+
+        public StringBuilder signedHeaderStringBuilder() {
+            if (signedHeaderStringBuilder == null) {
+                signedHeaderStringBuilder = new StringBuilder();
+                addSignedHeaders(signedHeaderStringBuilder, canonicalHeaders());
+            }
+            return signedHeaderStringBuilder;
+        }
+
+        public String signedHeaderString() {
+            if (signedHeaderString == null) {
+                this.signedHeaderString = signedHeaderStringBuilder().toString();
+            }
+            return signedHeaderString;
+        }
+
+        private List<Pair<String, List<String>>> canonicalHeaders() {
+            if (canonicalHeaders == null) {
+                canonicalHeaders = canonicalizeSigningHeaders(requestBuilder);
+            }
+            return canonicalHeaders;
+        }
+
+        private void addCanonicalizedHeaderString(StringBuilder result, List<Pair<String, List<String>>> canonicalizedHeaders) {
+            canonicalizedHeaders.forEach(header -> {
+                result.append(header.left());
+                result.append(":");
+                for (String headerValue : header.right()) {
+                    addAndTrim(result, headerValue);
+                    result.append(",");
+                }
+                result.setLength(result.length() - 1);
+                result.append("\n");
+            });
+        }
+
+        private List<Pair<String, List<String>>> canonicalizeSigningHeaders(SdkHttpFullRequest.Builder headers) {
+            List<Pair<String, List<String>>> result = new ArrayList<>(headers.numHeaders());
+
+            headers.forEachHeader((key, value) -> {
+                String lowerCaseHeader = lowerCase(key);
+                if (!LIST_OF_HEADERS_TO_IGNORE_IN_LOWER_CASE.contains(lowerCaseHeader)) {
+                    result.add(Pair.of(lowerCaseHeader, value));
+                }
+            });
+
+            result.sort(Comparator.comparing(Pair::left));
+
+            return result;
+        }
+
+        /**
+         * "The addAndTrim function removes excess white space before and after values,
+         * and converts sequential spaces to a single space."
+         * <p>
+         * https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
+         * <p>
+         * The collapse-whitespace logic is equivalent to:
+         * <pre>
+         *     value.replaceAll("\\s+", " ")
+         * </pre>
+         * but does not create a Pattern object that needs to compile the match
+         * string; it also prevents us from having to make a Matcher object as well.
+         */
+        private void addAndTrim(StringBuilder result, String value) {
+            int lengthBefore = result.length();
+            boolean isStart = true;
+            boolean previousIsWhiteSpace = false;
+
+            for (int i = 0; i < value.length(); i++) {
+                char ch = value.charAt(i);
+                if (isWhiteSpace(ch)) {
+                    if (previousIsWhiteSpace || isStart) {
+                        continue;
+                    }
+                    result.append(' ');
+                    previousIsWhiteSpace = true;
+                } else {
+                    result.append(ch);
+                    isStart = false;
+                    previousIsWhiteSpace = false;
+                }
+            }
+
+            if (lengthBefore == result.length()) {
+                return;
+            }
+
+            int lastNonWhitespaceChar = result.length() - 1;
+            while (isWhiteSpace(result.charAt(lastNonWhitespaceChar))) {
+                --lastNonWhitespaceChar;
+            }
+
+            result.setLength(lastNonWhitespaceChar + 1);
+        }
+
+        private void addSignedHeaders(StringBuilder result, List<Pair<String, List<String>>> canonicalizedHeaders) {
+            for (Pair<String, List<String>> header : canonicalizedHeaders) {
+                result.append(header.left()).append(';');
+            }
+
+            if (!canonicalizedHeaders.isEmpty()) {
+                result.setLength(result.length() - 1);
+            }
+        }
+    }
+}

--- a/trino-s3-proxy/src/main/java/software/amazon/awssdk/auth/signer/internal/CopiedAbstractAwsS3V4Signer.java
+++ b/trino-s3-proxy/src/main/java/software/amazon/awssdk/auth/signer/internal/CopiedAbstractAwsS3V4Signer.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.awssdk.auth.signer.internal;
+
+import static software.amazon.awssdk.auth.signer.internal.Aws4SignerUtils.calculateRequestContentLength;
+import static software.amazon.awssdk.auth.signer.internal.SignerConstant.X_AMZ_CONTENT_SHA256;
+
+import java.io.InputStream;
+import java.util.Optional;
+import software.amazon.awssdk.annotations.SdkInternalApi;
+import software.amazon.awssdk.auth.credentials.CredentialUtils;
+import software.amazon.awssdk.auth.signer.S3SignerExecutionAttribute;
+import software.amazon.awssdk.auth.signer.internal.chunkedencoding.AwsS3V4ChunkSigner;
+import software.amazon.awssdk.auth.signer.internal.chunkedencoding.AwsSignedChunkedEncodingInputStream;
+import software.amazon.awssdk.auth.signer.params.Aws4PresignerParams;
+import software.amazon.awssdk.auth.signer.params.AwsS3V4SignerParams;
+import software.amazon.awssdk.core.checksums.ChecksumSpecs;
+import software.amazon.awssdk.core.checksums.SdkChecksum;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.internal.chunked.AwsChunkedEncodingConfig;
+import software.amazon.awssdk.core.internal.util.HttpChecksumUtils;
+import software.amazon.awssdk.http.ContentStreamProvider;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.utils.BinaryUtils;
+import software.amazon.awssdk.utils.StringUtils;
+
+/**
+ * AWS4 signer implementation for AWS S3
+ */
+@SdkInternalApi
+public abstract class CopiedAbstractAwsS3V4Signer
+        extends CopiedAbstractAws4Signer<AwsS3V4SignerParams, Aws4PresignerParams>
+{
+
+    public static final String CONTENT_SHA_256_WITH_CHECKSUM = "STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER";
+    public static final String STREAMING_UNSIGNED_PAYLOAD_TRAILER = "STREAMING-UNSIGNED-PAYLOAD-TRAILER";
+
+    private static final String CONTENT_SHA_256 = "STREAMING-AWS4-HMAC-SHA256-PAYLOAD";
+    /**
+     * Sent to S3 in lieu of a payload hash when unsigned payloads are enabled
+     */
+    private static final String UNSIGNED_PAYLOAD = "UNSIGNED-PAYLOAD";
+    private static final String CONTENT_LENGTH = "Content-Length";
+
+
+    @Override
+    public SdkHttpFullRequest sign(SdkHttpFullRequest request, ExecutionAttributes executionAttributes) {
+        AwsS3V4SignerParams signingParams = constructAwsS3SignerParams(executionAttributes);
+
+        return sign(request, signingParams);
+    }
+
+    /**
+     * A method to sign the given #request. The parameters required for signing are provided through the modeled
+     * {@link CopiedAbstractAwsS3V4Signer} class.
+     *
+     * @param request The request to sign
+     * @param signingParams Class with the parameters used for signing the request
+     * @return A signed version of the input request
+     */
+    public SdkHttpFullRequest sign(SdkHttpFullRequest request, AwsS3V4SignerParams signingParams) {
+        // anonymous credentials, don't sign
+        if (CredentialUtils.isAnonymous(signingParams.awsCredentials())) {
+            return request;
+        }
+
+        Aws4SignerRequestParams requestParams = new Aws4SignerRequestParams(signingParams);
+
+        return doSign(request, requestParams, signingParams).build();
+    }
+
+    private AwsS3V4SignerParams constructAwsS3SignerParams(ExecutionAttributes executionAttributes) {
+        AwsS3V4SignerParams.Builder signerParams = extractSignerParams(AwsS3V4SignerParams.builder(),
+                                                                       executionAttributes);
+
+        Optional.ofNullable(executionAttributes.getAttribute(S3SignerExecutionAttribute.ENABLE_CHUNKED_ENCODING))
+                .ifPresent(signerParams::enableChunkedEncoding);
+
+        Optional.ofNullable(executionAttributes.getAttribute(S3SignerExecutionAttribute.ENABLE_PAYLOAD_SIGNING))
+                .ifPresent(signerParams::enablePayloadSigning);
+
+        return signerParams.build();
+    }
+
+    @Override
+    public SdkHttpFullRequest presign(SdkHttpFullRequest request, ExecutionAttributes executionAttributes) {
+        Aws4PresignerParams signingParams =
+            extractPresignerParams(Aws4PresignerParams.builder(), executionAttributes).build();
+
+        return presign(request, signingParams);
+    }
+
+    /**
+     * A method to pre sign the given #request. The parameters required for pre signing are provided through the modeled
+     * {@link Aws4PresignerParams} class.
+     *
+     * @param request The request to pre-sign
+     * @param signingParams Class with the parameters used for pre signing the request
+     * @return A pre signed version of the input request
+     */
+    public SdkHttpFullRequest presign(SdkHttpFullRequest request, Aws4PresignerParams signingParams) {
+        // anonymous credentials, don't sign
+        if (CredentialUtils.isAnonymous(signingParams.awsCredentials())) {
+            return request;
+        }
+
+        signingParams = signingParams.copy(b -> b.normalizePath(false));
+
+        Aws4SignerRequestParams requestParams = new Aws4SignerRequestParams(signingParams);
+
+        return doPresign(request, requestParams, signingParams).build();
+    }
+
+    /**
+     * If necessary, creates a chunk-encoding wrapper on the request payload.
+     */
+    @Override
+    protected void processRequestPayload(SdkHttpFullRequest.Builder mutableRequest,
+                                         byte[] signature,
+                                         byte[] signingKey,
+                                         Aws4SignerRequestParams signerRequestParams,
+                                         AwsS3V4SignerParams signerParams) {
+        processRequestPayload(mutableRequest, signature, signingKey,
+                              signerRequestParams, signerParams, null);
+    }
+
+    /**
+     * Overloads processRequestPayload with sdkChecksum.
+     * Flexible Checksum for Payload is calculated if sdkChecksum is passed.
+     */
+    @Override
+    protected void processRequestPayload(SdkHttpFullRequest.Builder mutableRequest,
+                                         byte[] signature,
+                                         byte[] signingKey,
+                                         Aws4SignerRequestParams signerRequestParams,
+                                         AwsS3V4SignerParams signerParams,
+                                         SdkChecksum sdkChecksum) {
+
+        if (useChunkEncoding(mutableRequest, signerParams)) {
+            if (mutableRequest.contentStreamProvider() != null) {
+                ContentStreamProvider streamProvider = mutableRequest.contentStreamProvider();
+
+                String headerForTrailerChecksumLocation = signerParams.checksumParams() != null
+                                                          ? signerParams.checksumParams().checksumHeaderName() : null;
+                mutableRequest.contentStreamProvider(() -> CopiedAbstractAwsS3V4Signer.this.asChunkEncodedStream(
+                        streamProvider.newStream(),
+                        signature,
+                        signingKey,
+                        signerRequestParams,
+                        sdkChecksum,
+                        headerForTrailerChecksumLocation)
+                );
+            }
+        }
+    }
+
+    @Override
+    protected String calculateContentHashPresign(SdkHttpFullRequest.Builder mutableRequest, Aws4PresignerParams signerParams) {
+        return UNSIGNED_PAYLOAD;
+    }
+
+    private AwsSignedChunkedEncodingInputStream asChunkEncodedStream(InputStream inputStream,
+                                                                     byte[] signature,
+                                                                     byte[] signingKey,
+                                                                     Aws4SignerRequestParams signerRequestParams,
+                                                                     SdkChecksum sdkChecksum,
+                                                                     String checksumHeaderForTrailer) {
+        AwsS3V4ChunkSigner chunkSigner = new AwsS3V4ChunkSigner(signingKey,
+                                                                signerRequestParams.getFormattedRequestSigningDateTime(),
+                                                                signerRequestParams.getScope());
+
+        return AwsSignedChunkedEncodingInputStream.builder()
+                                                  .inputStream(inputStream)
+                                                  .sdkChecksum(sdkChecksum)
+                                                  .checksumHeaderForTrailer(checksumHeaderForTrailer)
+                                                  .awsChunkSigner(chunkSigner)
+                                                  .headerSignature(BinaryUtils.toHex(signature))
+                                                  .awsChunkedEncodingConfig(AwsChunkedEncodingConfig.create())
+                                                  .build();
+    }
+
+    /**
+     * Returns the pre-defined header value and set other necessary headers if
+     * the request needs to be chunk-encoded. Otherwise calls the superclass
+     * method which calculates the hash of the whole content for signing.
+     */
+    @Override
+    protected String calculateContentHash(SdkHttpFullRequest.Builder mutableRequest, AwsS3V4SignerParams signerParams) {
+        return calculateContentHash(mutableRequest, signerParams, null);
+    }
+
+    /**
+     * This method overloads calculateContentHash with contentFlexibleChecksum.
+     * The contentFlexibleChecksum is computed at the same time while hash is calculated for Content.
+     */
+    @Override
+    protected String calculateContentHash(SdkHttpFullRequest.Builder mutableRequest, AwsS3V4SignerParams signerParams,
+                                          SdkChecksum contentFlexibleChecksum) {
+
+        // x-amz-content-sha256 marked as STREAMING_UNSIGNED_PAYLOAD_TRAILER in interceptors if Flexible checksum is set.
+        boolean isUnsignedStreamingTrailer = mutableRequest.firstMatchingHeader("x-amz-content-sha256")
+                                                    .map(STREAMING_UNSIGNED_PAYLOAD_TRAILER::equals)
+                                                    .orElse(false);
+
+        if (!isUnsignedStreamingTrailer) {
+            // To be consistent with other service clients using sig-v4,
+            // we just set the header as "required", and AWS4Signer.sign() will be
+            // notified to pick up the header value returned by this method.
+            mutableRequest.putHeader(X_AMZ_CONTENT_SHA256, "required");
+        }
+
+        if (isPayloadSigningEnabled(mutableRequest, signerParams)) {
+            if (useChunkEncoding(mutableRequest, signerParams)) {
+                long originalContentLength = calculateRequestContentLength(mutableRequest);
+                mutableRequest.putHeader("x-amz-decoded-content-length", Long.toString(originalContentLength));
+
+                boolean isTrailingChecksum = false;
+                if (signerParams.checksumParams() != null) {
+                    String headerForTrailerChecksumLocation =
+                        signerParams.checksumParams().checksumHeaderName();
+
+                    if (StringUtils.isNotBlank(headerForTrailerChecksumLocation) &&
+                        !HttpChecksumUtils.isHttpChecksumPresent(
+                            mutableRequest.build(),
+                            ChecksumSpecs.builder().headerName(signerParams.checksumParams().checksumHeaderName()).build())) {
+                        isTrailingChecksum = true;
+                        mutableRequest.putHeader("x-amz-trailer", headerForTrailerChecksumLocation);
+                        mutableRequest.appendHeader("Content-Encoding", "aws-chunked");
+                    }
+                }
+                // Make sure "Content-Length" header is not empty so that HttpClient
+                // won't cache the stream again to recover Content-Length
+                long calculateStreamContentLength = AwsSignedChunkedEncodingInputStream
+                    .calculateStreamContentLength(
+                        originalContentLength, AwsS3V4ChunkSigner.getSignatureLength(),
+                        AwsChunkedEncodingConfig.create(), isTrailingChecksum);
+                long checksumTrailerLength = isTrailingChecksum ? getChecksumTrailerLength(signerParams) : 0;
+                mutableRequest.putHeader(CONTENT_LENGTH, Long.toString(
+                    calculateStreamContentLength + checksumTrailerLength));
+                return isTrailingChecksum  ? CONTENT_SHA_256_WITH_CHECKSUM : CONTENT_SHA_256;
+            } else {
+                return super.calculateContentHash(mutableRequest, signerParams, contentFlexibleChecksum);
+            }
+        }
+
+        return isUnsignedStreamingTrailer ? STREAMING_UNSIGNED_PAYLOAD_TRAILER : UNSIGNED_PAYLOAD;
+    }
+
+    /**
+     * Determine whether to use aws-chunked for signing
+     */
+    private boolean useChunkEncoding(SdkHttpFullRequest.Builder mutableRequest, AwsS3V4SignerParams signerParams) {
+        // Chunked encoding only makes sense to do when the payload is signed
+        return isPayloadSigningEnabled(mutableRequest, signerParams) && isChunkedEncodingEnabled(signerParams);
+    }
+
+    /**
+     * @return True if chunked encoding has been enabled. Otherwise false.
+     */
+    private boolean isChunkedEncodingEnabled(AwsS3V4SignerParams signerParams) {
+        Boolean isChunkedEncodingEnabled = signerParams.enableChunkedEncoding();
+        return isChunkedEncodingEnabled != null && isChunkedEncodingEnabled;
+    }
+
+    /**
+     * @return True if payload signing is explicitly enabled.
+     */
+    private boolean isPayloadSigningEnabled(SdkHttpFullRequest.Builder request, AwsS3V4SignerParams signerParams) {
+        /**
+         * If we aren't using https we should always sign the payload unless there is no payload
+         */
+        if (!request.protocol().equals("https") && request.contentStreamProvider() != null) {
+            return true;
+        }
+
+        Boolean isPayloadSigningEnabled = signerParams.enablePayloadSigning();
+        return isPayloadSigningEnabled != null && isPayloadSigningEnabled;
+    }
+
+    public static long getChecksumTrailerLength(AwsS3V4SignerParams signerParams) {
+        return signerParams.checksumParams() == null ? 0
+                                                     : AwsSignedChunkedEncodingInputStream.calculateChecksumContentLength(
+                                                         signerParams.checksumParams().algorithm(),
+                                                         signerParams.checksumParams().checksumHeaderName(),
+                                                         AwsS3V4ChunkSigner.SIGNATURE_LENGTH);
+    }
+}

--- a/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/credentials/TestParsedAuthorization.java
+++ b/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/credentials/TestParsedAuthorization.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.s3.proxy.server.credentials;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.s3.proxy.server.credentials.ParsedAuthorization.Credential;
+import static io.trino.s3.proxy.server.credentials.ParsedAuthorization.parse;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestParsedAuthorization
+{
+    @Test
+    public void testValues()
+    {
+        assertThat(parse(null)).isEqualTo(new ParsedAuthorization("", new Credential("", ""), ImmutableSet.of(), ""));
+        assertThat(parse(null).isValid()).isFalse();
+
+        ParsedAuthorization parsedAuthorization = parse("AWS4-HMAC-SHA256 Credential=THIS_IS_AN_ACCESS_KEY/20240608/us-east-1/s3/aws4_request, SignedHeaders=amz-sdk-invocation-id;amz-sdk-request;amz-sdk-retry;content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=c23adc773b858c0bf6fa6885a047781606ab5dd114116136bd5a388d45ede8cd");
+        assertThat(parsedAuthorization.isValid()).isTrue();
+        assertThat(parsedAuthorization.credential()).isEqualTo(new Credential("THIS_IS_AN_ACCESS_KEY", "us-east-1"));
+        assertThat(parsedAuthorization.signedHeaders()).containsExactly("amz-sdk-invocation-id", "amz-sdk-request", "amz-sdk-retry", "content-type", "host", "user-agent", "x-amz-content-sha256", "x-amz-date");
+        assertThat(parsedAuthorization.signature()).isEqualTo("c23adc773b858c0bf6fa6885a047781606ab5dd114116136bd5a388d45ede8cd");
+
+        parsedAuthorization = parse("");
+        assertThat(parsedAuthorization.isValid()).isFalse();
+        assertThat(parsedAuthorization.signedHeaders()).isEmpty();
+        assertThat(parsedAuthorization.signature()).isEmpty();
+
+        parsedAuthorization = parse("x=y,,,,,,SignedHeaders=");
+        assertThat(parsedAuthorization.credential()).isEqualTo(new Credential("", ""));
+        assertThat(parsedAuthorization.signedHeaders()).isEmpty();
+        assertThat(parsedAuthorization.signature()).isEmpty();
+
+        parsedAuthorization = parse("x=y,,,,,,SignedHeaders=b;b;b;b;c,,,,,,,,,");
+        assertThat(parsedAuthorization.credential()).isEqualTo(new Credential("", ""));
+        assertThat(parsedAuthorization.signedHeaders()).containsExactly("b", "c");
+        assertThat(parsedAuthorization.signature()).isEmpty();
+
+        parsedAuthorization = parse("AWS4-HMAC-SHA256 Credential=x/y/z,SignedHeaders=1,Signature=foo");
+        assertThat(parsedAuthorization.isValid()).isTrue();
+        assertThat(parsedAuthorization.credential()).isEqualTo(new Credential("x", "z"));
+        assertThat(parsedAuthorization.signedHeaders()).containsExactly("1");
+        assertThat(parsedAuthorization.signature()).isEqualTo("foo");
+    }
+}

--- a/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/credentials/TestSigningController.java
+++ b/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/credentials/TestSigningController.java
@@ -112,4 +112,33 @@ public class TestSigningController
 
         assertThat(signature).isEqualTo("AWS4-HMAC-SHA256 Credential=THIS_IS_AN_ACCESS_KEY/20240516/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-security-token, Signature=222d7b7fcd4d5560c944e8fecd9424ee3915d131c3ad9e000d65db93e87946c4");
     }
+
+    @Test
+    public void testLegacy()
+    {
+        // values discovered from a Spark/Hive request sent to proxy LocalServer
+        MultivaluedMap<String, String> requestHeaders = new MultivaluedHashMap<>();
+        requestHeaders.putSingle("x-amz-content-sha256", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+        requestHeaders.putSingle("X-Amz-Date", "20240609T072007Z");
+        requestHeaders.putSingle("User-Agent", "Hadoop 3.3.4, aws-sdk-java/1.12.262 Linux/6.5.11-linuxkit OpenJDK_64-Bit_Server_VM/11.0.23+9 java/11.0.23 scala/2.12.18 vendor/Eclipse_Adoptium cfg/retry-mode/legacy");
+        requestHeaders.putSingle("Host", "host.docker.internal:57579");
+        requestHeaders.putSingle("amz-sdk-invocation-id", "fbb83f4e-a245-cc19-a318-001245fd3bc8");
+        requestHeaders.putSingle("amz-sdk-request", "attempt=1;max=21");
+        requestHeaders.putSingle("amz-sdk-retry", "0/0/500");
+        requestHeaders.putSingle("Content-Type", "application/octet-stream");
+
+        String signature = signingController.internalSignRequest(
+                SigningController.Mode.UNADJUSTED_HEADERS,
+                true,
+                false,
+                new SigningMetadata(SigningServiceType.S3, CREDENTIALS, Optional.empty(), "us-east-1"),
+                Credentials::emulated,
+                URI.create("http://host.docker.internal:57579/api/v1/s3Proxy/s3/sparkbyexamples/csv/text01.txt"),
+                requestHeaders,
+                new MultivaluedHashMap<>(),
+                "HEAD",
+                Optional.empty());
+
+        assertThat(signature).isEqualTo("AWS4-HMAC-SHA256 Credential=THIS_IS_AN_ACCESS_KEY/20240609/us-east-1/s3/aws4_request, SignedHeaders=amz-sdk-invocation-id;amz-sdk-request;amz-sdk-retry;content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=40d64a548e32b70a3b2a606b716ff8f16953f146b5365b6efd3a91125e304fd7");
+    }
 }

--- a/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/testing/harness/TrinoS3ProxyTestExtension.java
+++ b/trino-s3-proxy/src/test/java/io/trino/s3/proxy/server/testing/harness/TrinoS3ProxyTestExtension.java
@@ -17,14 +17,11 @@ import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
-import io.trino.s3.proxy.server.remote.RemoteS3Facade;
-import io.trino.s3.proxy.server.testing.ContainerS3Facade;
 import io.trino.s3.proxy.server.testing.ManagedS3MockContainer;
 import io.trino.s3.proxy.server.testing.ManagedS3MockContainer.ForS3MockContainer;
 import io.trino.s3.proxy.server.testing.TestingS3ClientProvider;
 import io.trino.s3.proxy.server.testing.TestingS3ClientProvider.ForS3ClientProvider;
 import io.trino.s3.proxy.server.testing.TestingTrinoS3ProxyServer;
-import io.trino.s3.proxy.server.testing.TestingUtil.ForTesting;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestInstanceFactory;
 import org.junit.jupiter.api.extension.TestInstanceFactoryContext;
@@ -39,7 +36,6 @@ import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
-import static io.trino.s3.proxy.server.testing.TestingUtil.TESTING_CREDENTIALS;
 
 public class TrinoS3ProxyTestExtension
         implements TestInstanceFactory, TestInstancePreDestroyCallback
@@ -66,13 +62,8 @@ public class TrinoS3ProxyTestExtension
                 .addModule(binder -> {
                     newOptionalBinder(binder, Key.get(String.class, ForS3ClientProvider.class));
                     binder.bind(S3Client.class).annotatedWith(ForS3MockContainer.class).toProvider(ManagedS3MockContainer.class);
-                    newOptionalBinder(binder, Key.get(RemoteS3Facade.class, ForTesting.class))
-                            .setDefault()
-                            .to(ContainerS3Facade.PathStyleContainerS3Facade.class)
-                            .asEagerSingleton();
                 })
                 .buildAndStart();
-        trinoS3ProxyServer.getCredentialsController().addCredentials(TESTING_CREDENTIALS);
         testingServersRegistry.put(extensionContext.getUniqueId(), trinoS3ProxyServer);
 
         Injector injector = trinoS3ProxyServer.getInjector()


### PR DESCRIPTION
Ad hoc testing shows that some clients are including the `user-agent`
header in the signature. The AWS signing code explicitly ignores this
header and, thus, these signatures don't match. The set of headers
to ignore is embedded in a private static final set and can't be
accessed or altered. Therefore, make copies of the auth code, mark
it as "copied", check for the presence of the `user-agent` signature
header and use this copied/legacy code in this case. This is legacy
code and, so, will never change so this is a safe method. Future
code changes would only affect non-legacy signatures.
