### PR TITLE
Validate the hash for standard, non-chunked input streams

### DIFF
--- a/trino-s3-proxy/src/main/java/io/trino/s3/proxy/server/rest/HashCheckInputStream.java
+++ b/trino-s3-proxy/src/main/java/io/trino/s3/proxy/server/rest/HashCheckInputStream.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.s3.proxy.server.rest;
+
+import com.google.common.hash.Hasher;
+import com.google.common.hash.Hashing;
+import io.airlift.log.Logger;
+import jakarta.ws.rs.WebApplicationException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Optional;
+
+import static jakarta.ws.rs.core.Response.Status.UNAUTHORIZED;
+import static java.util.Objects.requireNonNull;
+
+@SuppressWarnings("UnstableApiUsage")
+class HashCheckInputStream
+        extends InputStream
+{
+    private static final Logger log = Logger.get(HashCheckInputStream.class);
+
+    private final InputStream delegate;
+    private final String expectedHash;
+    private final Optional<Integer> expectedLength;
+    private final Hasher hasher;
+
+    private boolean hasBeenValidated;
+    private int bytesRead;
+
+    HashCheckInputStream(InputStream delegate, String expectedHash, Optional<Integer> expectedLength)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+        this.expectedHash = requireNonNull(expectedHash, "expectedHash is null");
+        this.expectedLength = requireNonNull(expectedLength, "expectedLength is null");
+
+        hasher = Hashing.sha256().newHasher();
+    }
+
+    @Override
+    public int read()
+            throws IOException
+    {
+        int i = delegate.read();
+        if (i < 0) {
+            validateHash();
+            return i;
+        }
+
+        hasher.putByte((byte) (i & 0xff));
+        updateBytesRead(1);
+
+        return i;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len)
+            throws IOException
+    {
+        int result = delegate.read(b, off, len);
+        if (result < 0) {
+            validateHash();
+            return result;
+        }
+
+        hasher.putBytes(b, off, result);
+        updateBytesRead(result);
+
+        return result;
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        delegate.close();
+    }
+
+    private void validateHash()
+    {
+        if (hasBeenValidated) {
+            return;
+        }
+        hasBeenValidated = true;
+
+        String actualHash = hasher.hash().toString();
+        if (!actualHash.equals(expectedHash)) {
+            log.debug("Actual hash does not match expected hash. Expected: %s, Actual: %s", expectedHash, actualHash);
+            throw new WebApplicationException(UNAUTHORIZED);
+        }
+    }
+
+    private void updateBytesRead(int count)
+    {
+        bytesRead += count;
+        expectedLength.ifPresent(expected -> {
+            if (bytesRead > expected) {
+                log.debug("More bytes read than expected. Expected: %s, Actual: %s", expected, bytesRead);
+                throw new WebApplicationException(UNAUTHORIZED);
+            }
+
+            if (bytesRead == expected) {
+                validateHash();
+            }
+        });
+    }
+}

--- a/trino-s3-proxy/src/main/java/io/trino/s3/proxy/server/signing/Signer.java
+++ b/trino-s3-proxy/src/main/java/io/trino/s3/proxy/server/signing/Signer.java
@@ -136,10 +136,10 @@ final class Signer
             return new WebApplicationException(Response.Status.BAD_REQUEST);
         });
 
-        return buildSigningContext(authorization, signingKey(credentials, new Aws4SignerRequestParams(signingParams)), requestDate);
+        return buildSigningContext(authorization, signingKey(credentials, new Aws4SignerRequestParams(signingParams)), requestDate, maybeAmazonContentHash);
     }
 
-    private static SigningContext buildSigningContext(String authorization, byte[] signingKey, String requestDate)
+    private static SigningContext buildSigningContext(String authorization, byte[] signingKey, String requestDate, Optional<String> contentHash)
     {
         RequestAuthorization requestAuthorization = RequestAuthorization.parse(authorization);
         if (!requestAuthorization.isValid()) {
@@ -148,7 +148,7 @@ final class Signer
         }
         ChunkSigner chunkSigner = new ChunkSigner(requestDate, requestAuthorization.keyPath(), signingKey);
         ChunkSigningSession chunkSigningSession = new InternalChunkSigningSession(chunkSigner, requestAuthorization.signature());
-        return new SigningContext(requestAuthorization, chunkSigningSession);
+        return new SigningContext(requestAuthorization, chunkSigningSession, contentHash);
     }
 
     private static boolean isLegacy(SigningHeaders signingHeaders)

--- a/trino-s3-proxy/src/main/java/io/trino/s3/proxy/server/signing/SigningContext.java
+++ b/trino-s3-proxy/src/main/java/io/trino/s3/proxy/server/signing/SigningContext.java
@@ -13,13 +13,16 @@
  */
 package io.trino.s3.proxy.server.signing;
 
+import java.util.Optional;
+
 import static java.util.Objects.requireNonNull;
 
-public record SigningContext(RequestAuthorization signingAuthorization, ChunkSigningSession chunkSigningSession)
+public record SigningContext(RequestAuthorization signingAuthorization, ChunkSigningSession chunkSigningSession, Optional<String> contentHash)
 {
     public SigningContext
     {
         requireNonNull(signingAuthorization, "signingAuthorization is null");
         requireNonNull(chunkSigningSession, "chunkSigningSession is null");
+        requireNonNull(contentHash, "contentHash is null");
     }
 }


### PR DESCRIPTION
For AWS requests that aren't chunked and that have a `x-amz-content-sha256` header, validate the hash of the input stream.

Closes #70