### PR TITLE
Handle trailer headers and unsigned aws chunked payloads

### DIFF
--- a/trino-aws-proxy-spi/src/main/java/io/trino/aws/proxy/spi/rest/RequestContent.java
+++ b/trino-aws-proxy-spi/src/main/java/io/trino/aws/proxy/spi/rest/RequestContent.java
@@ -13,7 +13,10 @@
  */
 package io.trino.aws.proxy.spi.rest;
 
+import com.google.common.collect.ImmutableList;
+
 import java.io.InputStream;
+import java.util.List;
 import java.util.Optional;
 
 @FunctionalInterface
@@ -27,7 +30,9 @@ public interface RequestContent
         STANDARD,
         W3C_CHUNKED,
         AWS_CHUNKED,
+        AWS_CHUNKED_UNSIGNED,
         AWS_CHUNKED_IN_W3C_CHUNKED,
+        AWS_CHUNKED_IN_W3C_CHUNKED_UNSIGNED,
     }
 
     default ContentType contentType()
@@ -46,6 +51,11 @@ public interface RequestContent
     default Optional<Integer> contentLength()
     {
         return Optional.empty();
+    }
+
+    default List<String> trailerHeaders()
+    {
+        return ImmutableList.of();
     }
 
     Optional<InputStream> inputStream();

--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/AwsChunkedInputStream.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/AwsChunkedInputStream.java
@@ -14,11 +14,13 @@
 package io.trino.aws.proxy.server.rest;
 
 import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
 import io.trino.aws.proxy.spi.signing.ChunkSigningSession;
 import jakarta.ws.rs.WebApplicationException;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -30,7 +32,7 @@ class AwsChunkedInputStream
         extends InputStream
 {
     private final InputStream delegate;
-    private final ChunkSigningSession chunkSigningSession;
+    private final Optional<ChunkSigningSession> chunkSigningSession;
 
     private enum State
     {
@@ -44,12 +46,14 @@ class AwsChunkedInputStream
     private int bytesRemainingInChunk;
     private int bytesAccountedFor;
     private final int decodedContentLength;
+    private final List<String> trailerHeaders;
 
-    AwsChunkedInputStream(InputStream delegate, ChunkSigningSession chunkSigningSession, int decodedContentLength)
+    AwsChunkedInputStream(InputStream delegate, Optional<ChunkSigningSession> chunkSigningSession, int decodedContentLength, List<String> trailerHeaders)
     {
         this.delegate = requireNonNull(delegate, "delegate is null");
         this.chunkSigningSession = requireNonNull(chunkSigningSession, "chunkSigningSession is null");
         this.decodedContentLength = decodedContentLength;
+        this.trailerHeaders = requireNonNull(ImmutableList.copyOf(trailerHeaders), "trailerHeaders is null");
     }
 
     @Override
@@ -65,7 +69,7 @@ class AwsChunkedInputStream
             throw new WebApplicationException("Unexpected end of stream", BAD_REQUEST);
         }
 
-        chunkSigningSession.write((byte) (i & 0xff));
+        chunkSigningSession.ifPresent(chunkSigningSession -> chunkSigningSession.write((byte) (i & 0xff)));
         updateBytesRemaining(1);
 
         return i;
@@ -86,7 +90,7 @@ class AwsChunkedInputStream
             throw new WebApplicationException("Unexpected end of stream", BAD_REQUEST);
         }
 
-        chunkSigningSession.write(b, off, count);
+        chunkSigningSession.ifPresent(chunkSigningSession -> chunkSigningSession.write(b, off, count));
         updateBytesRemaining(count);
 
         return count;
@@ -155,9 +159,6 @@ class AwsChunkedInputStream
         boolean success = false;
         do {
             List<String> parts = Splitter.on(';').trimResults().limit(2).splitToList(header);
-            if (parts.size() != 2) {
-                break;
-            }
 
             int chunkSize;
             try {
@@ -170,23 +171,41 @@ class AwsChunkedInputStream
                 break;
             }
 
-            Optional<String> chunkSignature = Splitter.on(';').trimResults().withKeyValueSeparator('=').split(parts.get(1))
-                    .entrySet()
-                    .stream()
-                    .filter(entry -> entry.getKey().equalsIgnoreCase("chunk-signature"))
-                    .map(Map.Entry::getValue)
-                    .findFirst();
+            if (chunkSigningSession.isPresent()) {
+                if (parts.size() != 2) {
+                    break;
+                }
 
-            if (chunkSignature.isEmpty()) {
-                break;
+                Optional<String> chunkSignature = Splitter.on(';').trimResults().withKeyValueSeparator('=').split(parts.get(1))
+                        .entrySet()
+                        .stream()
+                        .filter(entry -> entry.getKey().equalsIgnoreCase("chunk-signature"))
+                        .map(Map.Entry::getValue)
+                        .findFirst();
+
+                if (chunkSignature.isEmpty()) {
+                    break;
+                }
+
+                chunkSigningSession.get().startChunk(chunkSignature.get());
+            }
+            else {
+                if (parts.size() != 1) {
+                    break;
+                }
             }
 
-            chunkSigningSession.startChunk(chunkSignature.get());
             bytesRemainingInChunk = chunkSize;
 
             if (chunkSize == 0) {
-                readEmptyLine();
-                chunkSigningSession.complete();
+                if (trailerHeaders.isEmpty()) {
+                    readEmptyLine();
+                    chunkSigningSession.ifPresent(ChunkSigningSession::complete);
+                }
+                else {
+                    readTrailingHeaders();
+                    readEmptyLine();
+                }
                 state = State.LAST_CHUNK;
             }
             bytesAccountedFor += chunkSize;
@@ -236,4 +255,44 @@ class AwsChunkedInputStream
 
         return line.toString();
     }
+
+    private TrailerHeaderChunk readTrailingHeadersChunk()
+            throws IOException
+    {
+        Optional<String> signature = Optional.empty();
+        StringBuilder trailerHeadersChunkBuilder = new StringBuilder();
+        for (int i = 0; i < this.trailerHeaders.size(); i++) {
+            String trailerHeaders = readLine();
+            List<String> trailerHeadersValues = Splitter.on(":").trimResults().limit(2).splitToList(trailerHeaders);
+            String trailerHeaderName = trailerHeadersValues.getFirst();
+            if ((trailerHeadersValues.size() != 2) || !this.trailerHeaders.contains(trailerHeaderName)) {
+                throw new WebApplicationException("Trailer header is invalid: " + trailerHeaders, BAD_REQUEST);
+            }
+            if (trailerHeaderName.equals("x-amz-trailer-signature")) {
+                signature = Optional.of(trailerHeadersValues.getLast());
+                break;
+            }
+            else {
+                trailerHeadersChunkBuilder.append(trailerHeaders);
+            }
+        }
+        return new TrailerHeaderChunk(trailerHeadersChunkBuilder.toString(), signature);
+    }
+
+    private void readTrailingHeaders()
+            throws IOException
+    {
+        TrailerHeaderChunk trailerHeaderChunk = readTrailingHeadersChunk();
+        chunkSigningSession.ifPresent(chunkSigningSession -> {
+            if (trailerHeaderChunk.signature.isEmpty()) {
+                throw new WebApplicationException("Expected x-amz-trailer-signature, none found", BAD_REQUEST);
+            }
+            chunkSigningSession.startChunk(trailerHeaderChunk.signature.get());
+            byte[] trailerHeaderContent = trailerHeaderChunk.trailerHeaders.getBytes(StandardCharsets.UTF_8);
+            chunkSigningSession.write(trailerHeaderContent, 0, trailerHeaderContent.length);
+            chunkSigningSession.complete();
+        });
+    }
+
+    private record TrailerHeaderChunk(String trailerHeaders, Optional<String> signature) {}
 }

--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/RequestBuilder.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/RequestBuilder.java
@@ -15,6 +15,7 @@ package io.trino.aws.proxy.server.rest;
 
 import com.google.common.base.Splitter;
 import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableList;
 import io.airlift.log.Logger;
 import io.trino.aws.proxy.server.rest.RequestHeadersBuilder.InternalRequestHeaders;
 import io.trino.aws.proxy.server.signing.SigningQueryParameters;
@@ -152,7 +153,7 @@ class RequestBuilder
 
             // AWS does not mandate x-amz-decoded-content length is required for chunked transfer encoding
             // But we require it for simplicity (Content-Length is needed since we don't do chunking on outbound requests)
-            case AWS_CHUNKED, W3C_CHUNKED, AWS_CHUNKED_IN_W3C_CHUNKED -> () -> {
+            case AWS_CHUNKED, AWS_CHUNKED_UNSIGNED, W3C_CHUNKED, AWS_CHUNKED_IN_W3C_CHUNKED, AWS_CHUNKED_IN_W3C_CHUNKED_UNSIGNED -> () -> {
                 int contentLength = requestHeaders.decodedContentLength()
                         .orElseThrow(() -> new WebApplicationException(BAD_REQUEST));
                 return Optional.of(contentLength);
@@ -187,6 +188,12 @@ class RequestBuilder
                 return standardBytes()
                         .map(bytes -> (InputStream) new ByteArrayInputStream(bytes))
                         .or(() -> Optional.of(requestEntityStream));
+            }
+
+            @Override
+            public List<String> trailerHeaders()
+            {
+                return ImmutableList.copyOf(requestHeaders.requestHeaders().unmodifiedHeaders().get("x-amz-trailer"));
             }
         };
     }

--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/RequestHeadersBuilder.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/RequestHeadersBuilder.java
@@ -50,7 +50,8 @@ final class RequestHeadersBuilder
             "connection",
             "amz-sdk-invocation-id",
             "amx-sdk-request",
-            "host");
+            "host",
+            "x-amz-trailer");
 
     record InternalRequestHeaders(
             RequestHeaders requestHeaders,
@@ -75,7 +76,9 @@ final class RequestHeadersBuilder
         Builder builder = new Builder();
         allRequestHeaders.forEach((headerName, headerValues) -> {
             switch (headerName) {
-                case "authorization", "x-amz-security-token" -> {} // these get handled separately
+                case "authorization", "x-amz-security-token" -> {
+                    // these get handled separately
+                }
                 case "content-length" -> builder.contentLength(headerValues);
                 case "x-amz-decoded-content-length" -> builder.decodedContentLength(headerValues);
                 case "content-encoding" -> builder.contentEncoding(headerValues);
@@ -103,6 +106,13 @@ final class RequestHeadersBuilder
         private Optional<Integer> decodedContentLength = Optional.empty();
         private Optional<String> contentSha256 = Optional.empty();
         private Set<ContentType> seenRequestPayloadContentTypes = new HashSet<>();
+
+        private static final Set<ContentType> CHUNKED_CONTENT_TYPES = Set.of(
+                ContentType.AWS_CHUNKED,
+                ContentType.AWS_CHUNKED_IN_W3C_CHUNKED,
+                ContentType.W3C_CHUNKED,
+                ContentType.AWS_CHUNKED_UNSIGNED,
+                ContentType.AWS_CHUNKED_IN_W3C_CHUNKED_UNSIGNED);
 
         private Builder() {}
 
@@ -193,14 +203,18 @@ final class RequestHeadersBuilder
             passthroughHeadersBuilder.addAll(headerName, headerValues);
         }
 
+        private String requiredContentSha256()
+        {
+            return contentSha256.orElseThrow(() -> new WebApplicationException(BAD_REQUEST));
+        }
+
         private void assertContentTypeValid(ContentType actualContentType)
         {
-            if (actualContentType == ContentType.AWS_CHUNKED || actualContentType == ContentType.AWS_CHUNKED_IN_W3C_CHUNKED || actualContentType == ContentType.W3C_CHUNKED) {
+            if (CHUNKED_CONTENT_TYPES.contains(actualContentType)) {
                 if (decodedContentLength.isEmpty()) {
                     throw new WebApplicationException(LENGTH_REQUIRED);
                 }
-                String sha256 = contentSha256.orElseThrow(() -> new WebApplicationException(BAD_REQUEST));
-                if (actualContentType != ContentType.W3C_CHUNKED && !sha256.startsWith("STREAMING-")) {
+                if (actualContentType != ContentType.W3C_CHUNKED && !requiredContentSha256().startsWith("STREAMING-")) {
                     throw new WebApplicationException(BAD_REQUEST);
                 }
             }
@@ -209,10 +223,20 @@ final class RequestHeadersBuilder
         private InternalRequestHeaders build(MultiMap allHeaders)
         {
             Optional<ContentType> applicableContentType = switch (seenRequestPayloadContentTypes.size()) {
-                case 0, 1 -> seenRequestPayloadContentTypes.stream().findFirst();
+                case 0 -> Optional.empty();
+                case 1 -> {
+                    Optional<ContentType> contentType = seenRequestPayloadContentTypes.stream().findFirst();
+                    if (contentType.get().equals(ContentType.AWS_CHUNKED) && requiredContentSha256().startsWith("STREAMING-UNSIGNED-PAYLOAD")) {
+                        yield Optional.of(ContentType.AWS_CHUNKED_UNSIGNED);
+                    }
+                    yield contentType;
+                }
                 case 2 -> {
                     if (!seenRequestPayloadContentTypes.containsAll(ImmutableSet.of(ContentType.AWS_CHUNKED, ContentType.W3C_CHUNKED))) {
                         throw new WebApplicationException(BAD_REQUEST);
+                    }
+                    if (requiredContentSha256().startsWith("STREAMING-UNSIGNED-PAYLOAD")) {
+                        yield Optional.of(ContentType.AWS_CHUNKED_IN_W3C_CHUNKED_UNSIGNED);
                     }
                     yield Optional.of(ContentType.AWS_CHUNKED_IN_W3C_CHUNKED);
                 }

--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/TrinoS3ProxyClient.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/TrinoS3ProxyClient.java
@@ -212,8 +212,16 @@ public class TrinoS3ProxyClient
     {
         return switch (requestContent.contentType()) {
             case AWS_CHUNKED, AWS_CHUNKED_IN_W3C_CHUNKED -> requestContent.inputStream()
-                    .map(inputStream -> new AwsChunkedInputStream(limitStreamController.wrap(inputStream), signingMetadata.requiredSigningContext().chunkSigningSession(), requestContent.contentLength().orElseThrow()));
-
+                    .map(inputStream -> new AwsChunkedInputStream(limitStreamController.wrap(inputStream),
+                            Optional.of(signingMetadata.requiredSigningContext().chunkSigningSession()),
+                            requestContent.contentLength().orElseThrow(),
+                            requestContent.trailerHeaders()));
+            case AWS_CHUNKED_UNSIGNED, AWS_CHUNKED_IN_W3C_CHUNKED_UNSIGNED -> requestContent.inputStream()
+                    .map(inputStream -> new AwsChunkedInputStream(
+                            limitStreamController.wrap(inputStream),
+                            Optional.empty(),
+                            requestContent.contentLength().orElseThrow(),
+                            requestContent.trailerHeaders()));
             case STANDARD, W3C_CHUNKED -> requestContent.inputStream().map(inputStream -> {
                 SigningContext signingContext = signingMetadata.requiredSigningContext();
                 return signingContext.contentHash()

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestGenericRestRequests.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestGenericRestRequests.java
@@ -248,7 +248,7 @@ public class TestGenericRestRequests
 
         URI requestUri = UriBuilder.fromUri(baseUri).path(bucket).path(key).build();
         RequestAuthorization requestAuthorization = signRequest(requestSigningCredential, requestUri, requestDate, "PUT", requestHeaderBuilder.build());
-        String chunkedContent = chunkedPayloadMutator.apply(TestingChunkSigningSession.build(chunkSigningCredential, requestAuthorization.signature(), requestDate).generateChunkedStream(contentToUpload, partitionCount));
+        String chunkedContent = chunkedPayloadMutator.apply(TestingChunkSigningSession.build(chunkSigningCredential, requestAuthorization.signature(), requestDate).generateChunkedStream(contentToUpload, partitionCount, Optional.empty()));
         Request.Builder requestBuilder = preparePut().setUri(requestUri);
 
         requestHeaderBuilder.add("Authorization", requestAuthorization.authorization());

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestHttpChunked.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/TestHttpChunked.java
@@ -13,6 +13,7 @@
  */
 package io.trino.aws.proxy.server;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import io.airlift.http.client.HttpClient;
 import io.airlift.http.client.Request;
@@ -49,6 +50,8 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.UUID;
@@ -76,7 +79,6 @@ public class TestHttpChunked
     private final HttpClient httpClient;
     private final IdentityCredential testingCredentials;
     private final S3Client storageClient;
-
     private static final String TEST_CONTENT_TYPE = "text/plain;charset=utf-8";
     private static final Credential VALID_CREDENTIAL = new Credential(UUID.randomUUID().toString(), UUID.randomUUID().toString());
 
@@ -164,6 +166,8 @@ public class TestHttpChunked
     {
         String bucket = "test-http-chunked";
         String bucketTwo = "test-http-chunked-two";
+        String bucketThree = "test-http-chunked-three";
+
         storageClient.createBucket(r -> r.bucket(bucket).build());
         testHttpChunked(bucket, LOREM_IPSUM, "UNSIGNED-PAYLOAD", 1);
         testHttpChunked(bucket, LOREM_IPSUM, "UNSIGNED-PAYLOAD", 3);
@@ -173,6 +177,236 @@ public class TestHttpChunked
         testHttpChunked(bucketTwo, LOREM_IPSUM, sha256(LOREM_IPSUM), 1);
         testHttpChunked(bucketTwo, LOREM_IPSUM, sha256(LOREM_IPSUM), 3);
         testHttpChunked(bucketTwo, LOREM_IPSUM, sha256(LOREM_IPSUM), 5);
+
+        storageClient.createBucket(r -> r.bucket(bucketThree).build());
+        testHttpChunked(bucketThree, LOREM_IPSUM, "STREAMING-UNSIGNED-PAYLOAD-TRAILER", 1);
+        testHttpChunked(bucketThree, LOREM_IPSUM, "STREAMING-UNSIGNED-PAYLOAD-TRAILER", 3);
+        testHttpChunked(bucketThree, LOREM_IPSUM, "STREAMING-UNSIGNED-PAYLOAD-TRAILER", 5);
+    }
+
+    @Test
+    public void testHttpChunkedWithAwsChunkedEncodingUnsignedPayload()
+            throws IOException
+    {
+        Map<String, String> trailerHeaders = ImmutableMap.of("x-amz-checksum-crc32", "4ODU/w==");
+        testHttpChunkedWithAwsChunkedEncodingUnsignedPayloadSuccess(ImmutableMultiMap.empty(), Optional.of(trailerHeaders), Optional.empty());
+    }
+
+    @Test
+    public void testHttpChunkedWithAwsChunkedEncodingUnsignedPayloadMultipleEncodings()
+            throws IOException
+    {
+        Map<String, String> trailerHeaders = ImmutableMap.of("x-amz-checksum-crc32", "4ODU/w==");
+        ImmutableMultiMap.Builder extraHeaders = ImmutableMultiMap.builder(false)
+                .add("Content-Encoding", "aws-chunked").add("Content-Encoding", "gzip,compress");
+        testHttpChunkedWithAwsChunkedEncodingUnsignedPayloadSuccess(extraHeaders.build(), Optional.of(trailerHeaders), Optional.of("gzip,compress"));
+    }
+
+    @Test
+    public void testHttpChunkedWithAwsChunkedEncodingUnsignedPayloadNoTrailerHeaders()
+            throws IOException
+    {
+        ImmutableMultiMap.Builder extraHeaders = ImmutableMultiMap.builder(false).add("Content-Encoding", "gzip,compress");
+        testHttpChunkedWithAwsChunkedEncodingUnsignedPayloadSuccess(extraHeaders.build(), Optional.empty(), Optional.of("gzip,compress"));
+    }
+
+    @Test
+    public void testHttpChunkedWithAwsChunkedEncodingUnsignedPayloadWithMultipleTrailerHeaders()
+            throws IOException
+    {
+        Map<String, String> trailerHeaders = ImmutableMap.of("x-amz-checksum-something-else", "4ODU/w==",
+                "x-amz-checksum-something-else2", "10C");
+        testHttpChunkedWithAwsChunkedEncodingUnsignedPayloadSuccess(ImmutableMultiMap.empty(), Optional.of(trailerHeaders), Optional.empty());
+    }
+
+    @Test
+    public void testHttpChunkedWithAwsChunkedEncodingUnsignedPayloadWithInvalidTrailerHeadersPassed()
+    {
+        String bucket = "test-http-chunked-aws-chunked-header";
+        storageClient.createBucket(r -> r.bucket(bucket).build());
+        ImmutableMultiMap.Builder headersBuilder = ImmutableMultiMap.builder(false)
+                .add("X-Amz-Content-Sha256", "STREAMING-UNSIGNED-PAYLOAD-TRAILER")
+                .add("Content-Encoding", "aws-chunked")
+                .add("x-amz-trailer", "x-different-trailer");
+
+        assertThat(doCustomHttpChunkedUpload(
+                bucket,
+                "basic-upload",
+                3,
+                headersBuilder.build(),
+                LOREM_IPSUM.length(),
+                signature -> generateUnsignedChunkedStream(LOREM_IPSUM, 3,
+                        Optional.of(buildTrailerChunk(ImmutableMap.of("x-amz-unknown", "bla"))))
+        )).isEqualTo(400);
+    }
+
+    @Test
+    public void testHttpChunkedWithAwsChunkedEncodingUnsignedPayloadRaisesWhenNoValueForHeader()
+    {
+        String bucket = "test-http-chunked-aws-chunked-header";
+        storageClient.createBucket(r -> r.bucket(bucket).build());
+        ImmutableMultiMap.Builder headersBuilder = ImmutableMultiMap.builder(false)
+                .add("X-Amz-Content-Sha256", "STREAMING-UNSIGNED-PAYLOAD-TRAILER")
+                .add("Content-Encoding", "aws-chunked")
+                .add("x-amz-trailer", "x-some-trailer");
+
+        assertThat(doCustomHttpChunkedUpload(
+                bucket,
+                "basic-upload",
+                3,
+                headersBuilder.build(),
+                LOREM_IPSUM.length(),
+                signature -> generateUnsignedChunkedStream(LOREM_IPSUM, 3,
+                        Optional.empty())
+        )).isEqualTo(400);
+    }
+
+    @Test
+    public void testHttpChunkedValidatesSignature()
+    {
+        String bucket = "http-chunked-wrong-signature";
+        MultiMap requestHeaders = ImmutableMultiMap.builder(false)
+                .add("X-Amz-Content-Sha256", sha256(LOREM_IPSUM + "foo"))
+                .add("Content-Type", TEST_CONTENT_TYPE)
+                .build();
+        assertThat(doHttpChunkedUpload(bucket, "test-upload", LOREM_IPSUM, 3, requestHeaders)).isEqualTo(401);
+        assertFileNotInS3(storageClient, bucket, "test-upload");
+    }
+
+    @Test
+    public void testHttpChunkedContainingAwsChunkedPayload()
+            throws IOException
+    {
+        String bucket = "http-chunked-aws-chunked";
+        storageClient.createBucket(r -> r.bucket(bucket).build());
+
+        ImmutableMultiMap.Builder requestHeadersBuilder = ImmutableMultiMap.builder(false)
+                .add("X-Amz-Content-Sha256", "STREAMING-AWS4-HMAC-SHA256-PAYLOAD")
+                .add("Content-Encoding", "aws-chunked");
+        assertThat(
+                doCustomHttpChunkedUpload(bucket, "test-upload", 3,
+                        requestHeadersBuilder.build(), LOREM_IPSUM.length(),
+                        signature -> TestingChunkSigningSession.build(VALID_CREDENTIAL, signature).generateChunkedStream(LOREM_IPSUM, 3, Optional.empty())))
+                .isEqualTo(200);
+        assertThat(getFileFromStorage(storageClient, bucket, "test-upload")).isEqualTo(LOREM_IPSUM);
+
+        requestHeadersBuilder
+                .add("Content-Type", TEST_CONTENT_TYPE)
+                .add("Content-Encoding", "gzip,compress")
+                .add("x-amz-meta-foobar", "baz");
+        assertThat(doCustomHttpChunkedUpload(bucket, "test-upload-with-metadata", 3, requestHeadersBuilder.build(), LOREM_IPSUM.length(), signature -> TestingChunkSigningSession.build(VALID_CREDENTIAL, signature).generateChunkedStream(LOREM_IPSUM, 3, Optional.empty()))).isEqualTo(200);
+        assertThat(getFileFromStorage(storageClient, bucket, "test-upload-with-metadata")).isEqualTo(LOREM_IPSUM);
+        HeadObjectResponse objectMetadata = headObjectInStorage(storageClient, bucket, "test-upload-with-metadata");
+        assertThat(objectMetadata.contentType()).contains(TEST_CONTENT_TYPE);
+        assertThat(objectMetadata.contentEncoding()).isEqualTo("gzip,compress");
+        assertThat(objectMetadata.metadata()).containsEntry("foobar", "baz");
+    }
+
+    @Test
+    public void testHttpChunkedContainingAwsChunkedPayloadValidatesChunkSignatures()
+    {
+        String bucket = "http-chunked-aws-chunked-errors";
+        storageClient.createBucket(r -> r.bucket(bucket).build());
+
+        ImmutableMultiMap.Builder requestHeadersBuilder = ImmutableMultiMap.builder(false)
+                .add("X-Amz-Content-Sha256", "STREAMING-AWS4-HMAC-SHA256-PAYLOAD")
+                .add("Content-Encoding", "aws-chunked");
+        assertThat(doCustomHttpChunkedUpload(
+                bucket, "test-upload", 3, requestHeadersBuilder.build(), LOREM_IPSUM.length(),
+                signature -> TestingChunkSigningSession.build(new Credential(UUID.randomUUID().toString(), UUID.randomUUID().toString()), signature).generateChunkedStream(LOREM_IPSUM, 3, Optional.empty()))).isEqualTo(401);
+        assertFileNotInS3(storageClient, bucket, "test-upload");
+    }
+
+    @Test
+    public void testHttpChunkedContainingAwsChunkedPayloadWithTrailerHeaders()
+            throws IOException
+    {
+        String bucket = "http-chunked-aws-chunked";
+        storageClient.createBucket(r -> r.bucket(bucket).build());
+        Map<String, String> trailerHeaders = ImmutableMap.of("x-some-trailer", "foobarval");
+
+        ImmutableMultiMap.Builder requestHeadersBuilder = ImmutableMultiMap.builder(false)
+                .add("X-Amz-Content-Sha256", "STREAMING-AWS4-HMAC-SHA256-PAYLOAD")
+                .add("Content-Encoding", "aws-chunked");
+        requestHeadersBuilder.addAll("x-amz-trailer", buildTrailerHeaderValues(trailerHeaders));
+        requestHeadersBuilder.add("x-amz-trailer", "x-amz-trailer-signature");
+
+        assertThat(
+                doCustomHttpChunkedUpload(bucket, "test-upload", 3,
+                        requestHeadersBuilder.build(), LOREM_IPSUM.length(),
+                        signature -> TestingChunkSigningSession.build(VALID_CREDENTIAL, signature).generateChunkedStream(LOREM_IPSUM, 3, Optional.of(buildTrailerChunk(trailerHeaders)))))
+                .isEqualTo(200);
+        assertThat(getFileFromStorage(storageClient, bucket, "test-upload")).isEqualTo(LOREM_IPSUM);
+    }
+
+    private String buildTrailerChunk(Map<String, String> trailerHeaders)
+    {
+        StringBuilder chunk = new StringBuilder();
+        for (Map.Entry<String, String> entry : trailerHeaders.entrySet()) {
+            chunk.append(entry.getKey()).append(":").append(entry.getValue()).append("\r\n");
+        }
+        return chunk.toString();
+    }
+
+    private List<String> buildTrailerHeaderValues(Map<String, String> trailerHeaders)
+    {
+        return trailerHeaders.keySet().stream().toList();
+    }
+
+    public String generateUnsignedChunkedStream(String content, int partitions, Optional<String> trailerHeaders)
+    {
+        checkArgument(partitions > 1, "partitions must be greater than 1");
+        StringBuilder chunkedStream = new StringBuilder();
+        int chunkSize = Math.ceilDiv(content.length(), partitions);
+        int index = 0;
+        while (index < content.length()) {
+            int thisLength = Math.min(chunkSize, content.length() - index);
+            String thisChunk = content.substring(index, index + thisLength);
+            chunkedStream.append(Integer.toHexString(thisLength)).append("\r\n");
+            chunkedStream.append(thisChunk).append("\r\n");
+            index += thisLength;
+        }
+        chunkedStream.append("0").append("\r\n");
+
+        // trailer headers and end stream
+        trailerHeaders.ifPresent(chunkedStream::append);
+
+        // Mark end of entire streaming
+        chunkedStream.append("\r\n");
+        return chunkedStream.toString();
+    }
+
+    private void testHttpChunkedWithAwsChunkedEncodingUnsignedPayloadSuccess(MultiMap extraHeaders, Optional<Map<String, String>> trailerHeaders, Optional<String> expectedContent)
+            throws IOException
+    {
+        String bucket = "test-http-chunked-aws-chunked-header";
+        testHttpChunkedWithAwsChunkedEncodingUnsignedPayload(bucket, extraHeaders, trailerHeaders, 200);
+        assertThat(getFileFromStorage(storageClient, bucket, "basic-upload")).isEqualTo(LOREM_IPSUM);
+        if (expectedContent.isPresent()) {
+            assertThat(headObjectInStorage(storageClient, bucket, "basic-upload").contentEncoding()).isEqualTo(expectedContent.get());
+        }
+        else {
+            assertThat(headObjectInStorage(storageClient, bucket, "basic-upload").contentEncoding()).isNullOrEmpty();
+        }
+    }
+
+    private void testHttpChunkedWithAwsChunkedEncodingUnsignedPayload(String bucket, MultiMap extraHeaders, Optional<Map<String, String>> trailerHeaders, int expectedReturnCode)
+    {
+        storageClient.createBucket(r -> r.bucket(bucket).build());
+        ImmutableMultiMap.Builder headersBuilder = ImmutableMultiMap.builder(false)
+                .add("X-Amz-Content-Sha256", "STREAMING-UNSIGNED-PAYLOAD-TRAILER")
+                .add("Content-Encoding", "aws-chunked");
+        extraHeaders.forEach(headersBuilder::addAll);
+        trailerHeaders.ifPresent(e -> headersBuilder.addAll("x-amz-trailer", buildTrailerHeaderValues(e)));
+
+        assertThat(doCustomHttpChunkedUpload(
+                bucket,
+                "basic-upload",
+                3,
+                headersBuilder.build(),
+                LOREM_IPSUM.length(),
+                signature -> generateUnsignedChunkedStream(LOREM_IPSUM, 3, trailerHeaders.map(this::buildTrailerChunk)))
+        ).isEqualTo(expectedReturnCode);
     }
 
     private void testHttpChunked(String bucket, String content, String sha256, int partitionCount)
@@ -206,58 +440,6 @@ public class TestHttpChunked
         assertThat(withFields.contentType()).contains(TEST_CONTENT_TYPE);
         assertThat(withFields.contentEncoding()).isEqualTo("gzip,compress");
         assertThat(withFields.metadata()).containsEntry("foobar", "baz");
-    }
-
-    @Test
-    public void testHttpChunkedValidatesSignature()
-    {
-        String bucket = "http-chunked-wrong-signature";
-        MultiMap requestHeaders = ImmutableMultiMap.builder(false)
-                .add("X-Amz-Content-Sha256", sha256(LOREM_IPSUM + "foo"))
-                .add("Content-Type", TEST_CONTENT_TYPE)
-                .build();
-        assertThat(doHttpChunkedUpload(bucket, "test-upload", LOREM_IPSUM, 3, requestHeaders)).isEqualTo(401);
-        assertFileNotInS3(storageClient, bucket, "test-upload");
-    }
-
-    @Test
-    public void testHttpChunkedContainingAwsChunkedPayload()
-            throws IOException
-    {
-        String bucket = "http-chunked-aws-chunked";
-        storageClient.createBucket(r -> r.bucket(bucket).build());
-
-        ImmutableMultiMap.Builder requestHeadersBuilder = ImmutableMultiMap.builder(false)
-                .add("X-Amz-Content-Sha256", "STREAMING-AWS4-HMAC-SHA256-PAYLOAD")
-                .add("Content-Encoding", "aws-chunked");
-        assertThat(doCustomHttpChunkedUpload(bucket, "test-upload", 3, requestHeadersBuilder.build(), LOREM_IPSUM.length(), signature -> TestingChunkSigningSession.build(VALID_CREDENTIAL, signature).generateChunkedStream(LOREM_IPSUM, 3))).isEqualTo(200);
-        assertThat(getFileFromStorage(storageClient, bucket, "test-upload")).isEqualTo(LOREM_IPSUM);
-
-        requestHeadersBuilder
-                .add("Content-Type", TEST_CONTENT_TYPE)
-                .add("Content-Encoding", "gzip,compress")
-                .add("x-amz-meta-foobar", "baz");
-        assertThat(doCustomHttpChunkedUpload(bucket, "test-upload-with-metadata", 3, requestHeadersBuilder.build(), LOREM_IPSUM.length(), signature -> TestingChunkSigningSession.build(VALID_CREDENTIAL, signature).generateChunkedStream(LOREM_IPSUM, 3))).isEqualTo(200);
-        assertThat(getFileFromStorage(storageClient, bucket, "test-upload-with-metadata")).isEqualTo(LOREM_IPSUM);
-        HeadObjectResponse objectMetadata = headObjectInStorage(storageClient, bucket, "test-upload-with-metadata");
-        assertThat(objectMetadata.contentType()).contains(TEST_CONTENT_TYPE);
-        assertThat(objectMetadata.contentEncoding()).isEqualTo("gzip,compress");
-        assertThat(objectMetadata.metadata()).containsEntry("foobar", "baz");
-    }
-
-    @Test
-    public void testHttpChunkedContainingAwsChunkedPayloadValidatesChunkSignatures()
-    {
-        String bucket = "http-chunked-aws-chunked-errors";
-        storageClient.createBucket(r -> r.bucket(bucket).build());
-
-        ImmutableMultiMap.Builder requestHeadersBuilder = ImmutableMultiMap.builder(false)
-                .add("X-Amz-Content-Sha256", "STREAMING-AWS4-HMAC-SHA256-PAYLOAD")
-                .add("Content-Encoding", "aws-chunked");
-        assertThat(doCustomHttpChunkedUpload(
-                bucket, "test-upload", 3, requestHeadersBuilder.build(), LOREM_IPSUM.length(),
-                signature -> TestingChunkSigningSession.build(new Credential(UUID.randomUUID().toString(), UUID.randomUUID().toString()), signature).generateChunkedStream(LOREM_IPSUM, 3))).isEqualTo(401);
-        assertFileNotInS3(storageClient, bucket, "test-upload");
     }
 
     private int doHttpChunkedUpload(String bucket, String key, String content, int chunkCount, MultiMap extraHeaders)

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/rest/TestAwsChunkedInputStream.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/rest/TestAwsChunkedInputStream.java
@@ -29,6 +29,8 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -68,35 +70,51 @@ public class TestAwsChunkedInputStream
             throws IOException
     {
         TestingChunkSigningSession session = goodTestSigningSession();
-        String chunkedStream = session.generateChunkedStream(GOOD_CONTENT, 3);
+        String chunkedStream = session.generateChunkedStream(GOOD_CONTENT, 3, Optional.empty());
 
-        assertThat(readChunked(chunkedStream, session)).isEqualTo(GOOD_CONTENT.getBytes(UTF_8));
+        assertThat(readChunked(chunkedStream, session, ImmutableList.of())).isEqualTo(GOOD_CONTENT.getBytes(UTF_8));
     }
 
     @Test
     public void testRecreateSessionValidatesGoodPayload()
             throws IOException
     {
-        String chunkedStream = goodTestSigningSession().generateChunkedStream(GOOD_CONTENT, 3);
+        String chunkedStream = goodTestSigningSession().generateChunkedStream(GOOD_CONTENT, 3, Optional.empty());
 
-        assertThat(readChunked(chunkedStream, goodTestSigningSession())).isEqualTo(GOOD_CONTENT.getBytes(UTF_8));
+        assertThat(readChunked(chunkedStream, goodTestSigningSession(), ImmutableList.of())).isEqualTo(GOOD_CONTENT.getBytes(UTF_8));
+    }
+
+    @Test
+    public void testRecreateSessionValidatesGoodPayloadWithTrailerHeader()
+            throws IOException
+    {
+        String chunkedStream = goodTestSigningSession().generateChunkedStream(GOOD_CONTENT, 3, Optional.of("x-amz-header1:foo\r\n"));
+        assertThat(readChunked(chunkedStream, goodTestSigningSession(), ImmutableList.of("x-amz-header1", "x-amz-trailer-signature"))).isEqualTo(GOOD_CONTENT.getBytes(UTF_8));
+    }
+
+    @Test
+    public void testRecreateSessionValidatesGoodPayloadWithTrailerHeaders()
+            throws IOException
+    {
+        String chunkedStream = goodTestSigningSession().generateChunkedStream(GOOD_CONTENT, 3, Optional.of("x-amz-header2:foo\r\nx-amz-header1:foo\r\n"));
+        assertThat(readChunked(chunkedStream, goodTestSigningSession(), ImmutableList.of("x-amz-header1", "x-amz-header2", "x-amz-trailer-signature"))).isEqualTo(GOOD_CONTENT.getBytes(UTF_8));
     }
 
     @Test
     public void testBadSeed()
     {
-        String chunkedStream = goodTestSigningSession().generateChunkedStream(GOOD_CONTENT, 3);
+        String chunkedStream = goodTestSigningSession().generateChunkedStream(GOOD_CONTENT, 3, Optional.empty());
 
-        assertThatThrownBy(() -> readChunked(chunkedStream, TestingChunkSigningSession.build(GOOD_CREDENTIAL, BAD_SEED)))
+        assertThatThrownBy(() -> readChunked(chunkedStream, TestingChunkSigningSession.build(GOOD_CREDENTIAL, BAD_SEED), ImmutableList.of()))
                 .isInstanceOf(WebApplicationException.class);
     }
 
     @Test
     public void testBadCredential()
     {
-        String chunkedStream = goodTestSigningSession().generateChunkedStream(GOOD_CONTENT, 3);
+        String chunkedStream = goodTestSigningSession().generateChunkedStream(GOOD_CONTENT, 3, Optional.empty());
 
-        assertThatThrownBy(() -> readChunked(chunkedStream, TestingChunkSigningSession.build(BAD_CREDENTIAL, BAD_SEED)))
+        assertThatThrownBy(() -> readChunked(chunkedStream, TestingChunkSigningSession.build(BAD_CREDENTIAL, BAD_SEED), ImmutableList.of()))
                 .isInstanceOf(WebApplicationException.class);
     }
 
@@ -104,10 +122,10 @@ public class TestAwsChunkedInputStream
     public void testMultipleExtensions()
             throws IOException
     {
-        String chunkedStream = goodTestSigningSession().generateChunkedStream(GOOD_CONTENT, 3);
+        String chunkedStream = goodTestSigningSession().generateChunkedStream(GOOD_CONTENT, 3, Optional.empty());
         chunkedStream = chunkedStream.replace(";chunk-signature=", ";foo=bar;chunk-signature=");
 
-        assertThat(readChunked(chunkedStream, goodTestSigningSession())).isEqualTo(GOOD_CONTENT.getBytes(UTF_8));
+        assertThat(readChunked(chunkedStream, goodTestSigningSession(), ImmutableList.of())).isEqualTo(GOOD_CONTENT.getBytes(UTF_8));
     }
 
     @Test
@@ -251,7 +269,7 @@ public class TestAwsChunkedInputStream
             throws IOException
     {
         int remainingBytes = decodedContentLength;
-        try (InputStream in = new AwsChunkedInputStream(new ByteArrayInputStream(chunkedData.getBytes(UTF_8)), signingSession, decodedContentLength)) {
+        try (InputStream in = new AwsChunkedInputStream(new ByteArrayInputStream(chunkedData.getBytes(UTF_8)), Optional.of(signingSession), decodedContentLength, ImmutableList.of())) {
             while (remainingBytes > 0) {
                 byte[] readBytes = new byte[bytesToReadAtATime];
                 int count = in.read(readBytes, 0, bytesToReadAtATime);
@@ -268,7 +286,7 @@ public class TestAwsChunkedInputStream
             throws IOException
     {
         int remainingBytes = decodedContentLength;
-        try (InputStream in = new AwsChunkedInputStream(new ByteArrayInputStream(chunkedData.getBytes(UTF_8)), signingSession, decodedContentLength)) {
+        try (InputStream in = new AwsChunkedInputStream(new ByteArrayInputStream(chunkedData.getBytes(UTF_8)), Optional.of(signingSession), decodedContentLength, ImmutableList.of())) {
             while (remainingBytes-- > 0) {
                 int readByte = in.read();
                 if (readByte == -1) {
@@ -286,10 +304,10 @@ public class TestAwsChunkedInputStream
         assertThat(testOutput.toByteArray().length).isLessThan(decodedContentLength);
     }
 
-    private static byte[] readChunked(String chunkedStream, TestingChunkSigningSession signingSession)
+    private static byte[] readChunked(String chunkedStream, TestingChunkSigningSession signingSession, List<String> trailerHeaders)
             throws IOException
     {
-        try (InputStream in = new AwsChunkedInputStream(new ByteArrayInputStream(chunkedStream.getBytes(UTF_8)), signingSession, chunkedStream.length())) {
+        try (InputStream in = new AwsChunkedInputStream(new ByteArrayInputStream(chunkedStream.getBytes(UTF_8)), Optional.of(signingSession), chunkedStream.length(), ImmutableList.copyOf(trailerHeaders))) {
             return ByteStreams.toByteArray(in);
         }
     }
@@ -308,7 +326,7 @@ public class TestAwsChunkedInputStream
     {
         byte[] rawBytes = CHUNKED_INPUT.getBytes(UTF_8);
         ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
-        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession(), rawBytes.length);
+        InputStream in = new AwsChunkedInputStream(inputStream, Optional.of(new DummyChunkSigningSession()), rawBytes.length, ImmutableList.of());
         byte[] buffer = new byte[300];
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         int len;
@@ -331,7 +349,7 @@ public class TestAwsChunkedInputStream
     {
         byte[] rawBytes = CHUNKED_INPUT.getBytes(UTF_8);
         ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
-        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession(), rawBytes.length);
+        InputStream in = new AwsChunkedInputStream(inputStream, Optional.of(new DummyChunkSigningSession()), rawBytes.length, ImmutableList.of());
 
         byte[] buffer = new byte[7];
         ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -354,7 +372,7 @@ public class TestAwsChunkedInputStream
         String s = "5;chunk-signature=0\r\n01234\r\n5;chunk-signature=0\r\n56789\r\n0;chunk-signature=0\r\n\r\n";
         byte[] rawBytes = s.getBytes(UTF_8);
         ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
-        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession(), rawBytes.length);
+        InputStream in = new AwsChunkedInputStream(inputStream, Optional.of(new DummyChunkSigningSession()), rawBytes.length, ImmutableList.of());
         int ch;
         int i = '0';
         while ((ch = in.read()) != -1) {
@@ -374,7 +392,7 @@ public class TestAwsChunkedInputStream
         String s = "5;chunk-signature=0\r\n01234\r\n";
         byte[] rawBytes = s.getBytes(UTF_8);
         ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
-        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession(), rawBytes.length);
+        InputStream in = new AwsChunkedInputStream(inputStream, Optional.of(new DummyChunkSigningSession()), rawBytes.length, ImmutableList.of());
         byte[] tmp = new byte[5];
         // altered from original test. Our AwsChunkedInputStream is improved and throws when the final chunk is missing or bad
         assertThrows(WebApplicationException.class, () -> in.read(tmp));
@@ -390,7 +408,7 @@ public class TestAwsChunkedInputStream
                 .forEach(s -> {
                     byte[] rawBytes = s.getBytes(UTF_8);
                     ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
-                    InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession(), rawBytes.length);
+                    InputStream in = new AwsChunkedInputStream(inputStream, Optional.of(new DummyChunkSigningSession()), rawBytes.length, ImmutableList.of());
                     byte[] tmp = new byte[5];
                     // altered from original test. Our AwsChunkedInputStream is improved and throws when the final chunk is missing or bad
                     assertThrows(WebApplicationException.class, () -> in.read(tmp));
@@ -410,7 +428,7 @@ public class TestAwsChunkedInputStream
         String s = "5;chunk-signature=0\r\n012345\r\n56789\r\n0;chunk-signature=0\r\n\r\n";
         byte[] rawBytes = s.getBytes(UTF_8);
         ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
-        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession(), rawBytes.length);
+        InputStream in = new AwsChunkedInputStream(inputStream, Optional.of(new DummyChunkSigningSession()), rawBytes.length, ImmutableList.of());
         byte[] buffer = new byte[300];
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         assertThrows(WebApplicationException.class, () -> {
@@ -430,7 +448,7 @@ public class TestAwsChunkedInputStream
         String s = "5;chunk-signature=0\r01234\r\n5;chunk-signature=0\r\n56789\r\n0;chunk-signature=0\r\n\r\n";
         byte[] rawBytes = s.getBytes(UTF_8);
         ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
-        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession(), rawBytes.length);
+        InputStream in = new AwsChunkedInputStream(inputStream, Optional.of(new DummyChunkSigningSession()), rawBytes.length, ImmutableList.of());
         assertThrows(WebApplicationException.class, in::read);
         in.close();
     }
@@ -443,7 +461,7 @@ public class TestAwsChunkedInputStream
         String s = "whatever;chunk-signature=0\r\n01234\r\n5;chunk-signature=0\r\n56789\r\n0;chunk-signature=0\r\n\r\n";
         byte[] rawBytes = s.getBytes(UTF_8);
         ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
-        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession(), rawBytes.length);
+        InputStream in = new AwsChunkedInputStream(inputStream, Optional.of(new DummyChunkSigningSession()), rawBytes.length, ImmutableList.of());
         assertThrows(WebApplicationException.class, in::read);
         in.close();
     }
@@ -456,7 +474,7 @@ public class TestAwsChunkedInputStream
         String s = "-5;chunk-signature=0\r\n01234\r\n5;chunk-signature=0\r\n56789\r\n0;chunk-signature=0\r\n\r\n";
         byte[] rawBytes = s.getBytes(UTF_8);
         ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
-        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession(), rawBytes.length);
+        InputStream in = new AwsChunkedInputStream(inputStream, Optional.of(new DummyChunkSigningSession()), rawBytes.length, ImmutableList.of());
         assertThrows(WebApplicationException.class, in::read);
         in.close();
     }
@@ -469,7 +487,7 @@ public class TestAwsChunkedInputStream
         String s = "3;chunk-signature=0\r\n12";
         byte[] rawBytes = s.getBytes(UTF_8);
         ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
-        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession(), rawBytes.length);
+        InputStream in = new AwsChunkedInputStream(inputStream, Optional.of(new DummyChunkSigningSession()), rawBytes.length, ImmutableList.of());
         byte[] buffer = new byte[300];
         assertEquals(2, in.read(buffer));
         assertThrows(WebApplicationException.class, () -> in.read(buffer));
@@ -482,7 +500,7 @@ public class TestAwsChunkedInputStream
         String s = "whatever;chunk-signature=0\r\n01234\r\n5;chunk-signature=0\r\n56789\r\n0;chunk-signature=0\r\n\r\n";
         byte[] rawBytes = s.getBytes(UTF_8);
         ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
-        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession(), rawBytes.length);
+        InputStream in = new AwsChunkedInputStream(inputStream, Optional.of(new DummyChunkSigningSession()), rawBytes.length, ImmutableList.of());
         assertThrows(WebApplicationException.class, in::read);
     }
 
@@ -493,7 +511,7 @@ public class TestAwsChunkedInputStream
         String s = "0;chunk-signature=0\r\n\r\n";
         byte[] rawBytes = s.getBytes(UTF_8);
         ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
-        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession(), rawBytes.length);
+        InputStream in = new AwsChunkedInputStream(inputStream, Optional.of(new DummyChunkSigningSession()), rawBytes.length, ImmutableList.of());
         byte[] buffer = new byte[300];
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         int len;
@@ -511,7 +529,7 @@ public class TestAwsChunkedInputStream
     {
         byte[] rawBytes = "499602D2;chunk-signature=0\r\n01234567".getBytes(UTF_8);
         ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
-        InputStream in = new AwsChunkedInputStream(inputStream, new DummyChunkSigningSession(), 1234567890);
+        InputStream in = new AwsChunkedInputStream(inputStream, Optional.of(new DummyChunkSigningSession()), 1234567890, ImmutableList.of());
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         for (int i = 0; i < 8; ++i) {
@@ -520,6 +538,238 @@ public class TestAwsChunkedInputStream
 
         String result = out.toString(UTF_8);
         assertEquals("01234567", result);
+    }
+
+    @Test
+    public void testChunkedInputStreamWithTrailerHeaderChunk()
+            throws IOException
+    {
+        String s = "5;chunk-signature=0\r\n01234\r\n5;chunk-signature=0\r\n56789\r\n0;chunk-signature=0\r\nx-amz-header1:foo\r\nx-amz-trailer-signature:0\r\n\r\n";
+        byte[] rawBytes = s.getBytes(UTF_8);
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
+        InputStream in = new AwsChunkedInputStream(inputStream, Optional.of(new DummyChunkSigningSession()), rawBytes.length, ImmutableList.of("x-amz-header1", "x-amz-trailer-signature"));
+
+        byte[] buffer = new byte[7];
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int len;
+        while ((len = in.read(buffer)) > 0) {
+            out.write(buffer, 0, len);
+        }
+        assertEquals(-1, in.read(buffer));
+        assertEquals(-1, in.read(buffer));
+
+        String result = out.toString(UTF_8);
+        assertEquals("0123456789", result);
+
+        in.close();
+    }
+
+    @Test
+    public void testChunkedInputStreamWithTrailerHeaderChunkMultipleTrailers()
+            throws IOException
+    {
+        String s = "5;chunk-signature=0\r\n01234\r\n5;chunk-signature=0\r\n56789\r\n0;chunk-signature=0\r\nx-amz-header1:foo\r\nx-amz-header2:foo\r\nx-amz-trailer-signature:0\r\n\r\n";
+        byte[] rawBytes = s.getBytes(UTF_8);
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
+        InputStream in = new AwsChunkedInputStream(inputStream, Optional.of(new DummyChunkSigningSession()), rawBytes.length, ImmutableList.of("x-amz-header1", "x-amz-header2", "x-amz-trailer-signature"));
+
+        byte[] buffer = new byte[7];
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int len;
+        while ((len = in.read(buffer)) > 0) {
+            out.write(buffer, 0, len);
+        }
+        assertEquals(-1, in.read(buffer));
+        assertEquals(-1, in.read(buffer));
+
+        String result = out.toString(UTF_8);
+        assertEquals("0123456789", result);
+
+        in.close();
+    }
+
+    @Test
+    public void testCorruptChunkedInputStreamWithTrailerHeaderChunkNoneExpected()
+            throws IOException
+    {
+        String s = "5;chunk-signature=0\r\n01234\r\n5;chunk-signature=0\r\n56789\r\n0;chunk-signature=0\r\nx-amz-header1:foo\r\nx-amz-trailer-signature:0\r\n\r\n";
+        byte[] rawBytes = s.getBytes(UTF_8);
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
+        InputStream in = new AwsChunkedInputStream(inputStream, Optional.of(new DummyChunkSigningSession()), rawBytes.length, ImmutableList.of());
+
+        byte[] buffer = new byte[7];
+        assertThrows(WebApplicationException.class, () -> {
+            while (in.read(buffer) > 0) {
+                // do nothing
+            }
+        });
+        in.close();
+    }
+
+    @Test
+    public void testCorruptChunkedInputStreamWithTrailerHeaderSignatureBeforeHeader()
+            throws IOException
+    {
+        String s = "5;chunk-signature=0\r\n01234\r\n5;chunk-signature=0\r\n56789\r\n0;chunk-signature=0\r\nx-amz-trailer-signature:0\r\nx-amz-header1:foo\r\n\r\n";
+        byte[] rawBytes = s.getBytes(UTF_8);
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
+        InputStream in = new AwsChunkedInputStream(inputStream, Optional.of(new DummyChunkSigningSession()), rawBytes.length, ImmutableList.of("x-amz-trailer-signature", "x-amz-header1"));
+
+        byte[] buffer = new byte[7];
+        assertThrows(WebApplicationException.class, () -> {
+            while (in.read(buffer) > 0) {
+                // do nothing
+            }
+        });
+        in.close();
+    }
+
+    @Test
+    public void testCorruptChunkedInputStreamWithTrailerHeaderChunkNoSignature()
+            throws IOException
+    {
+        String s = "5;chunk-signature=0\r\n01234\r\n5;chunk-signature=0\r\n56789\r\n0;chunk-signature=0\r\nx-amz-header1:foo\r\n\r\n";
+        byte[] rawBytes = s.getBytes(UTF_8);
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
+        InputStream in = new AwsChunkedInputStream(inputStream, Optional.of(new DummyChunkSigningSession()), rawBytes.length, ImmutableList.of("x-amz-header1"));
+
+        byte[] buffer = new byte[7];
+        assertThrows(WebApplicationException.class, () -> {
+            while (in.read(buffer) > 0) {
+                // do nothing
+            }
+        });
+        in.close();
+    }
+
+    @Test
+    public void testChunkedInputStreamUnsigned()
+            throws IOException
+    {
+        String s = "5\r\n01234\r\n5\r\n56789\r\n0\r\n\r\n";
+        byte[] rawBytes = s.getBytes(UTF_8);
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
+        InputStream in = new AwsChunkedInputStream(inputStream, Optional.empty(), rawBytes.length, ImmutableList.of());
+
+        byte[] buffer = new byte[7];
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int len;
+        while ((len = in.read(buffer)) > 0) {
+            out.write(buffer, 0, len);
+        }
+        assertEquals(-1, in.read(buffer));
+        assertEquals(-1, in.read(buffer));
+
+        String result = out.toString(UTF_8);
+        assertEquals("0123456789", result);
+
+        in.close();
+    }
+
+    @Test
+    public void testChunkedInputStreamUnsignedWithTrailerHeaderChunk1Header()
+            throws IOException
+    {
+        String s = "5\r\n01234\r\n5\r\n56789\r\n0\r\nx-amz-header1:val\r\n\r\n";
+        byte[] rawBytes = s.getBytes(UTF_8);
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
+        InputStream in = new AwsChunkedInputStream(inputStream, Optional.empty(), rawBytes.length, ImmutableList.of("x-amz-header1"));
+
+        byte[] buffer = new byte[7];
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int len;
+        while ((len = in.read(buffer)) > 0) {
+            out.write(buffer, 0, len);
+        }
+        assertEquals(-1, in.read(buffer));
+        assertEquals(-1, in.read(buffer));
+
+        String result = out.toString(UTF_8);
+        assertEquals("0123456789", result);
+
+        in.close();
+    }
+
+    @Test
+    public void testChunkedInputStreamUnsignedWithTrailerHeaderChunkMultipleHeader()
+            throws IOException
+    {
+        String s = "5\r\n01234\r\n5\r\n56789\r\n0\r\nx-amz-header1:val\r\nx-amz-header2:val\r\n\r\n";
+        byte[] rawBytes = s.getBytes(UTF_8);
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
+        InputStream in = new AwsChunkedInputStream(inputStream, Optional.empty(), rawBytes.length, ImmutableList.of("x-amz-header1", "x-amz-header2"));
+
+        byte[] buffer = new byte[7];
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int len;
+        while ((len = in.read(buffer)) > 0) {
+            out.write(buffer, 0, len);
+        }
+        assertEquals(-1, in.read(buffer));
+        assertEquals(-1, in.read(buffer));
+
+        String result = out.toString(UTF_8);
+        assertEquals("0123456789", result);
+
+        in.close();
+    }
+
+    @Test
+    public void testChunkedInputStreamUnsignedWithTrailerHeaderChunkMultipleHeaderOutOfOrder()
+            throws IOException
+    {
+        String s = "5\r\n01234\r\n5\r\n56789\r\n0\r\nx-amz-header1:val\r\nx-amz-header2:val\r\n\r\n";
+        byte[] rawBytes = s.getBytes(UTF_8);
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
+        InputStream in = new AwsChunkedInputStream(inputStream, Optional.empty(), rawBytes.length, ImmutableList.of("x-amz-header2", "x-amz-header1"));
+
+        byte[] buffer = new byte[7];
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int len;
+        while ((len = in.read(buffer)) > 0) {
+            out.write(buffer, 0, len);
+        }
+        assertEquals(-1, in.read(buffer));
+        assertEquals(-1, in.read(buffer));
+
+        String result = out.toString(UTF_8);
+        assertEquals("0123456789", result);
+
+        in.close();
+    }
+
+    @Test
+    public void testCorruptUnsignedChunkedInputStreamTrailerHeadersWithNoneExpected()
+            throws IOException
+    {
+        String s = "5\r\n01234\r\n5\r\n56789\r\n0\r\nx-amz-trailer:val\r\n\r\n";
+        byte[] rawBytes = s.getBytes(UTF_8);
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
+        InputStream in = new AwsChunkedInputStream(inputStream, Optional.empty(), rawBytes.length, ImmutableList.of());
+        byte[] buffer = new byte[7];
+        assertThrows(WebApplicationException.class, () -> {
+            while (in.read(buffer) > 0) {
+                // do nothing
+            }
+        });
+        in.close();
+    }
+
+    @Test
+    public void testCorruptUnsignedChunkedInputStreamMissingTrailerHeaderChunk()
+            throws IOException
+    {
+        String s = "5\r\n01234\r\n5\r\n56789\r\n0\r\n\r\n";
+        byte[] rawBytes = s.getBytes(UTF_8);
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(rawBytes);
+        InputStream in = new AwsChunkedInputStream(inputStream, Optional.empty(), rawBytes.length, ImmutableList.of("x-amz-trailer-foo"));
+        byte[] buffer = new byte[7];
+        assertThrows(WebApplicationException.class, () -> {
+            while (in.read(buffer) > 0) {
+                // do nothing
+            }
+        });
+        in.close();
     }
 
     private static class DummyChunkSigningSession

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/rest/TestRequestHeadersBuilder.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/rest/TestRequestHeadersBuilder.java
@@ -25,6 +25,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
+import static io.trino.aws.proxy.spi.rest.RequestContent.ContentType.AWS_CHUNKED_IN_W3C_CHUNKED_UNSIGNED;
+import static io.trino.aws.proxy.spi.rest.RequestContent.ContentType.AWS_CHUNKED_UNSIGNED;
 import static io.trino.aws.proxy.spi.rest.RequestContent.ContentType.W3C_CHUNKED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -83,9 +85,9 @@ public class TestRequestHeadersBuilder
     private void testBuildHeadersAwsChunkedPayload(MultiMap baseHeaders, ContentType expectedContentType)
     {
         assertThatThrownBy(() -> doBuildHeaders(mergeMaps(baseHeaders, ImmutableMultiMap.builder(false)
-                        .add("X-Amz-Content-Sha256", "UNSIGNED-PAYLOAD")
-                        .add("Content-Encoding", "aws-chunked")
-                        .build()))).isInstanceOf(WebApplicationException.class);
+                .add("X-Amz-Content-Sha256", "UNSIGNED-PAYLOAD")
+                .add("Content-Encoding", "aws-chunked")
+                .build()))).isInstanceOf(WebApplicationException.class);
 
         testBuildHeaders(
                 mergeMaps(
@@ -122,6 +124,52 @@ public class TestRequestHeadersBuilder
     }
 
     @Test
+    public void testBuildHeadersHttpAndAwsChunkedUnsignedPayload()
+    {
+        // Testing our corner case where we want to handle aws-chunked requests with a STREAMING-UNSIGNED-PAYLOAD hash
+        // as if they were W3C chunked, and not aws-chunked.
+        ImmutableMultiMap baseHeaders = ImmutableMultiMap.builder(false)
+                .add("transfer-encoding", "chunked")
+                .add("content-encoding", "aws-chunked")
+                .add("Content-Encoding", "gzip")
+                .add("x-amz-trailer", "x-amz-checksum-crc32")
+                .add("x-amz-content-sha256", "STREAMING-UNSIGNED-PAYLOAD-TRAILER")
+                .add("x-amz-decoded-content-length", "1234")
+                .build();
+
+        testBuildHeaders(
+                mergeMaps(
+                        baseHeaders,
+                        ImmutableMultiMap.builder(false)
+                                .build()),
+                ImmutableMultiMap.builder(false).add("Content-Encoding", "gzip").build(),
+                Optional.of(AWS_CHUNKED_IN_W3C_CHUNKED_UNSIGNED));
+    }
+
+    @Test
+    public void testBuildHeadersAwsChunkedUnsignedPayload()
+    {
+        // Testing our corner case where we want to handle aws-chunked requests with a STREAMING-UNSIGNED-PAYLOAD hash
+        // as if they were W3C chunked, and not aws-chunked.
+        ImmutableMultiMap baseHeaders = ImmutableMultiMap.builder(false)
+                .add("content-encoding", "aws-chunked")
+                .add("Content-Encoding", "gzip")
+                .add("x-amz-trailer", "x-amz-checksum-crc32")
+                .add("x-amz-content-sha256", "STREAMING-UNSIGNED-PAYLOAD-TRAILER")
+                .add("Content-Length", "1234")
+                .add("X-Amz-Decoded-Content-Length", "1234")
+                .build();
+
+        testBuildHeaders(
+                mergeMaps(
+                        baseHeaders,
+                        ImmutableMultiMap.builder(false)
+                                .build()),
+                ImmutableMultiMap.builder(false).add("Content-Encoding", "gzip").build(),
+                Optional.of(AWS_CHUNKED_UNSIGNED));
+    }
+
+    @Test
     public void testBuildHeadersHttpChunked()
     {
         MultiMap baseHttpChunkedHeaders = ImmutableMultiMap.builder(false)
@@ -129,13 +177,6 @@ public class TestRequestHeadersBuilder
                 .add("Transfer-Encoding", "chunked")
                 .add("X-Amz-Decoded-Content-Length", "1000")
                 .build();
-        testBuildHeaders(baseHttpChunkedHeaders, ImmutableMultiMap.empty(), Optional.of(W3C_CHUNKED));
-
-        MultiMap metadataHeaders = ImmutableMultiMap.builder(false).add("X-Amz-Some-Metadata", "foo").build();
-        testBuildHeaders(
-                mergeMaps(baseHttpChunkedHeaders, metadataHeaders),
-                metadataHeaders,
-                Optional.of(W3C_CHUNKED));
 
         testBuildHeaders(
                 mergeMaps(

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/signing/TestingChunkSigningSession.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/signing/TestingChunkSigningSession.java
@@ -26,7 +26,9 @@ import software.amazon.awssdk.regions.Region;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -90,7 +92,7 @@ public class TestingChunkSigningSession
     }
 
     @SuppressWarnings("UnstableApiUsage")
-    public String generateChunkedStream(String content, int partitions)
+    public String generateChunkedStream(String content, int partitions, Optional<String> trailerHeaders)
     {
         checkArgument(partitions > 1, "partitions must be greater than 1");
 
@@ -112,7 +114,16 @@ public class TestingChunkSigningSession
         }
 
         String thisSignature = chunkSigner.signChunk(Hashing.sha256().newHasher().hash(), previousSignature);
-        chunkedStream.append("0;chunk-signature=").append(thisSignature).append("\r\n\r\n");
+        chunkedStream.append("0;chunk-signature=").append(thisSignature).append("\r\n");
+
+        trailerHeaders.ifPresent(headers -> {
+            chunkedStream.append(headers);
+            String trailerSignature = getChunkSignature(Arrays.stream(headers.split("\r\n")).reduce("", (prev, next) -> prev + next), thisSignature);
+            chunkedStream.append("x-amz-trailer-signature:").append(trailerSignature).append("\r\n");
+        });
+
+        // Mark end of entire Streaming
+        chunkedStream.append("\r\n");
 
         return chunkedStream.toString();
     }


### PR DESCRIPTION
This PR does Addresses https://github.com/trinodb/aws-proxy/issues/199 

It does provide support for
- Trailer headers regardless of whether they are part of a signed or unsigned aws chunked request
- It handles aws chunked unsigned requests

Overall changes
- Create new types AWS_CHUNKED_UNSIGNED and AWS_CHUNKED_IN_W3C_CHUNKED_UNSIGNED in ContentType
- Make ChunkSigningSession optional in AwsChunkedInputStream class
- Support reading the trailer header chunk as part of AwsChunkedInputStream class. Check [docs](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming-trailers.html) for reference on the trailer headers chunk.

## Summary by Sourcery

Add support for AWS chunked payloads that include trailer headers and handle unsigned AWS-chunked streams throughout the proxy stack.

New Features:
- Support reading and validating trailer header chunks in signed AWS-chunked streams
- Handle unsigned AWS-chunked payloads with optional trailer headers

Enhancements:
- Introduce AWS_CHUNKED_UNSIGNED and AWS_CHUNKED_IN_W3C_CHUNKED_UNSIGNED content types
- Make chunk signing session optional and track configured trailer headers in AwsChunkedInputStream
- Propagate trailer header lists through RequestHeadersBuilder, RequestContent, RequestBuilder, and TrinoS3ProxyClient

Tests:
- Extend AwsChunkedInputStream tests for trailer headers, signed and unsigned streams
- Add HTTP chunked upload tests for unsigned AWS-chunked encoding and trailer header validations
- Update request headers builder and generic request tests to cover new unsigned AWS-chunked scenarios