### PR TITLE
Fix query parameters encoding in rewritten target requests

### DIFF
--- a/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/TrinoS3ProxyClient.java
+++ b/trino-aws-proxy/src/main/java/io/trino/aws/proxy/server/rest/TrinoS3ProxyClient.java
@@ -60,6 +60,8 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static java.util.Objects.requireNonNull;
+import static org.glassfish.jersey.uri.UriComponent.Type.QUERY_PARAM;
+import static org.glassfish.jersey.uri.UriComponent.encode;
 
 public class TrinoS3ProxyClient
 {
@@ -238,7 +240,7 @@ public class TrinoS3ProxyClient
     private static UriBuilder uriBuilder(MultiMap queryParameters)
     {
         UriBuilder uriBuilder = UriBuilder.newInstance();
-        queryParameters.forEachEntry(uriBuilder::queryParam);
+        queryParameters.forEachEntry((name, value) -> uriBuilder.queryParam(name, encode(value, QUERY_PARAM)));
         return uriBuilder;
     }
 

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/AbstractTestProxiedRequests.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/AbstractTestProxiedRequests.java
@@ -252,6 +252,33 @@ public abstract class AbstractTestProxiedRequests
     }
 
     @Test
+    public void testPathsNeedingEscapingAsQueryParam()
+    {
+        String bucket = "escapes-query";
+        String targetBucket = requestRewriteController.getTargetBucket(bucket, "");
+        remoteClient.createBucket(r -> r.bucket(targetBucket));
+        internalClient.putObject(r -> r.bucket(bucket).key("a=1/b=2/1"), RequestBody.fromString("something"));
+        internalClient.putObject(r -> r.bucket(bucket).key("a=1%2Fb=2/2"), RequestBody.fromString("else"));
+
+        assertThat(listFilesInS3Bucket(remoteClient, targetBucket, requestRewriteController.getTargetKey(bucket, "a=1/b=2")))
+                .containsExactlyInAnyOrder(requestRewriteController.getTargetKey(bucket, "a=1/b=2/1"));
+        // Provide target key prefix - rewriting query parameters is not supported
+        assertThat(listFilesInS3Bucket(internalClient, bucket, requestRewriteController.getTargetKey(bucket, "a=1/b=2")))
+                .containsExactlyInAnyOrder(requestRewriteController.getTargetKey(bucket, "a=1/b=2/1"));
+
+        assertThat(listFilesInS3Bucket(remoteClient, targetBucket, requestRewriteController.getTargetKey(bucket, "a=1%2Fb=2")))
+                .containsExactlyInAnyOrder(requestRewriteController.getTargetKey(bucket, "a=1%2Fb=2/2"));
+        // Provide target key prefix - rewriting query parameters is not supported
+        assertThat(listFilesInS3Bucket(internalClient, bucket, requestRewriteController.getTargetKey(bucket, "a=1%2Fb=2")))
+                .containsExactlyInAnyOrder(requestRewriteController.getTargetKey(bucket, "a=1%2Fb=2/2"));
+
+        internalClient.deleteObject(r -> r.bucket(bucket).key("a=1/b=2/1"));
+        internalClient.deleteObject(r -> r.bucket(bucket).key("a=1%2Fb=2/2"));
+        assertThat(listFilesInS3Bucket(internalClient, bucket)).isEmpty();
+        internalClient.deleteBucket(r -> r.bucket(bucket));
+    }
+
+    @Test
     public void testKeyOrBucketDoesNotExist()
     {
         assertFileNotInS3(internalClient, UUID.randomUUID().toString(), UUID.randomUUID().toString());

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/TestingUtil.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/TestingUtil.java
@@ -150,6 +150,11 @@ public final class TestingUtil
         return storageClient.listObjects(request -> request.bucket(bucket)).contents().stream().map(S3Object::key).collect(toImmutableList());
     }
 
+    public static List<String> listFilesInS3Bucket(S3Client storageClient, String bucket, String prefix)
+    {
+        return storageClient.listObjects(request -> request.bucket(bucket).prefix(prefix)).contents().stream().map(S3Object::key).collect(toImmutableList());
+    }
+
     @SuppressWarnings("UnstableApiUsage")
     public static String sha256(String content)
     {


### PR DESCRIPTION
Fixes request rewriting when query parameters contain a value that matches a percent-encoded value (e.g. `%2F`).

Previously, such values were not encoded when adding query parameters to the rewritten request, as the method used internally by `JerseyUriBuilder.queryParam` to encode values (UriComponent.contextualEncode) is recognizing percent-encoded values to avoid double-encoding. This led to changing the original request, and subsequently the remote denying the request with `SignatureDoesNotMatch` error.

To fix this, we can encode all query parameter values before passing them to the URI builder, as we know that they require encoding.