### PR TITLE
Migrate to Chainguard MinIO container

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,8 @@
         <dep.airlift-units.version>1.10</dep.airlift-units.version>
         <dep.jersey.version>3.1.9</dep.jersey.version>
         <dep.testcontainers.version>1.19.8</dep.testcontainers.version>
-        <dep.minio.version>8.5.9</dep.minio.version>
+        <!-- in sync with container cgr.dev/chainguard/minio in S3Container -->
+        <dep.minio.version>8.6.0</dep.minio.version>
         <dep.docker.version>3.3.6</dep.docker.version>
         <dep.awaitility.version>4.1.1</dep.awaitility.version>
         <dep.caffeine.version>3.1.8</dep.caffeine.version>

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/containers/S3Container.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/containers/S3Container.java
@@ -49,8 +49,8 @@ public class S3Container
 
     public static final String POLICY_NAME = "managedPolicy";
 
-    private static final String IMAGE_NAME = "minio/minio";
-    private static final String IMAGE_TAG = "RELEASE.2024-07-15T19-02-30Z";
+    // Keep in sync with dep.minio.version in pom.xml
+    private static final String IMAGE = "cgr.dev/chainguard/minio@sha256:66bd82c8fe5e75868ae7d0b2e102d9a0dcf971b270a41bd060a9e6a643476ff8";
 
     private static final String CONFIG_TEMPLATE = """
             {
@@ -111,7 +111,7 @@ public class S3Container
         Transferable config = Transferable.of(CONFIG_TEMPLATE.formatted(credential.accessKey(), credential.secretKey()));
         Transferable policyFile = Transferable.of(POLICY);
 
-        container = new MinIOContainer(DockerImageName.parse(IMAGE_NAME).withTag(IMAGE_TAG))
+        container = new MinIOContainer(DockerImageName.parse(IMAGE).asCompatibleSubstituteFor("minio/minio"))
                 .withUserName(credential.accessKey())
                 .withPassword(credential.secretKey())
                 .withEnv("MC_CONFIG_DIR", "/root/.mc/")
@@ -120,6 +120,8 @@ public class S3Container
                 .withCopyToContainer(policyFile, "/root/policy.json");
 
         container.withEnv("MINIO_DOMAIN", LOCALHOST_DOMAIN);
+        // Required to create buckets externally
+        container.withCreateContainerCmdModifier(cmd -> cmd.withUser("root"));
         container.start();
 
         log.info("S3 container started on port: %s", container.getFirstMappedPort());


### PR DESCRIPTION
A similar change was already done in Trino since the minio:minio container is unmaintained now. At least this way we will continue to get security updates from a maintained container.

https://github.com/trinodb/trino/pull/27131/files

In a follow up PR I will look at renovatebot or digestabot use for updates.

For renovate I will have to make a custom setup I think - https://docs.renovatebot.com/modules/manager/regex/

digestabot probably wont work unless I do some weird hack
