### PR TITLE
Bump version for Testcontainers and Docker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,10 +54,10 @@
         <dep.aws-sdk.version>2.25.32</dep.aws-sdk.version>
         <dep.airlift-units.version>1.10</dep.airlift-units.version>
         <dep.jersey.version>3.1.9</dep.jersey.version>
-        <dep.testcontainers.version>1.19.8</dep.testcontainers.version>
+        <dep.testcontainers.version>1.21.4</dep.testcontainers.version>
         <!-- in sync with container cgr.dev/chainguard/minio in S3Container -->
         <dep.minio.version>9.0.3</dep.minio.version>
-        <dep.docker.version>3.3.6</dep.docker.version>
+        <dep.docker.version>3.7.1</dep.docker.version>
         <dep.awaitility.version>4.1.1</dep.awaitility.version>
         <dep.caffeine.version>3.1.8</dep.caffeine.version>
     </properties>


### PR DESCRIPTION
Newer versions of Docker doesn't support old test-containers versions.