### PR TITLE
Update Minio container image and client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <dep.jersey.version>3.1.9</dep.jersey.version>
         <dep.testcontainers.version>1.19.8</dep.testcontainers.version>
         <!-- in sync with container cgr.dev/chainguard/minio in S3Container -->
-        <dep.minio.version>8.6.0</dep.minio.version>
+        <dep.minio.version>9.0.3</dep.minio.version>
         <dep.docker.version>3.3.6</dep.docker.version>
         <dep.awaitility.version>4.1.1</dep.awaitility.version>
         <dep.caffeine.version>3.1.8</dep.caffeine.version>

--- a/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/containers/S3Container.java
+++ b/trino-aws-proxy/src/test/java/io/trino/aws/proxy/server/testing/containers/S3Container.java
@@ -50,7 +50,7 @@ public class S3Container
     public static final String POLICY_NAME = "managedPolicy";
 
     // Keep in sync with dep.minio.version in pom.xml
-    private static final String IMAGE = "cgr.dev/chainguard/minio@sha256:f2aba4b9c84b61881933142f1cb7cc1a20f8e8456f1f1aa353ddd248f23037f7";
+    private static final String IMAGE = "cgr.dev/chainguard/minio@sha256:f767919bd003062ac69713cdce920eb922c9fa3388efe96264e78b763342ca1a";
 
     private static final String CONFIG_TEMPLATE = """
             {


### PR DESCRIPTION
Bump the Chainguard minio image to `RELEASE.2026-07-17T12-07-51Z`, pinned by digest in the `S3Container` test fixture, and bump the `io.minio:minio` client from 8.6.0 to 9.0.3 to keep it aligned. The client is a test-scoped dependency and the module test-compiles against v9.

This version includes the fix from https://github.com/chainguard-forks/minio/pull/37.

This mirrors the equivalent container update in the core [trinodb/trino](https://github.com/trinodb/trino) repository.

Assisted-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>